### PR TITLE
Enhance UI with basic features and navigation

### DIFF
--- a/src/ui/AnalyticsDashboard.tsx
+++ b/src/ui/AnalyticsDashboard.tsx
@@ -1,10 +1,23 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function AnalyticsDashboard() {
+  const [metrics, setMetrics] = useState<any>(null);
+
+  useEffect(() => {
+    fetch('/analytics/revenue').then(r => r.json()).then(setMetrics).catch(() => {});
+  }, []);
+
   return (
     <div>
       <h2>Analytics</h2>
-      <div id="metrics">Metrics will appear here</div>
+      {metrics ? (
+        <div>
+          <div>Revenue: ${metrics.revenue ?? 0}</div>
+          <div>Clicks: {metrics.clicks ?? 0}</div>
+        </div>
+      ) : (
+        <div id="metrics">Loading metrics...</div>
+      )}
     </div>
   );
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,17 +1,45 @@
-import React from 'react';
+import React, { useState } from 'react';
 import LoginForm from './LoginForm';
 import SessionConnect from './SessionConnect';
 import CampaignEditor from './CampaignEditor';
 import AnalyticsDashboard from './AnalyticsDashboard';
+import CampaignMonitor from './CampaignMonitor';
+import { StateProvider } from './Store';
+import ErrorBoundary from './ErrorBoundary';
+
+type Page = 'login' | 'session' | 'editor' | 'monitor' | 'analytics';
 
 export default function App() {
+  const [page, setPage] = useState<Page>('login');
+
+  const renderPage = () => {
+    switch (page) {
+      case 'login':
+        return <LoginForm onSuccess={() => setPage('session')} />;
+      case 'session':
+        return <SessionConnect onSuccess={() => setPage('editor')} />;
+      case 'editor':
+        return <CampaignEditor />;
+      case 'monitor':
+        return <CampaignMonitor />;
+      case 'analytics':
+        return <AnalyticsDashboard />;
+    }
+  };
+
   return (
-    <div>
-      <h1>Telegram Retargeting Platform</h1>
-      <LoginForm />
-      <SessionConnect />
-      <CampaignEditor />
-      <AnalyticsDashboard />
-    </div>
+    <ErrorBoundary>
+      <StateProvider>
+        <div className="container">
+          <h1>Telegram Retargeting Platform</h1>
+          <nav>
+            <a onClick={() => setPage('editor')}>Editor</a>
+            <a onClick={() => setPage('monitor')}>Monitor</a>
+            <a onClick={() => setPage('analytics')}>Analytics</a>
+          </nav>
+          {renderPage()}
+        </div>
+      </StateProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/ui/CampaignEditor.tsx
+++ b/src/ui/CampaignEditor.tsx
@@ -1,25 +1,89 @@
 import React, { useState } from 'react';
+import RichTextEditor from './RichTextEditor';
+
+const placeholders = [
+  { label: 'First Name', value: '{{first_name}}' },
+  { label: 'Last Order', value: '{{last_order}}' },
+  { label: 'Discount Code', value: '{{discount_code}}' }
+];
 
 export default function CampaignEditor() {
   const [message, setMessage] = useState('');
+  const [media, setMedia] = useState<File | null>(null);
+  const [category, setCategory] = useState('');
+  const [quietStart, setQuietStart] = useState('');
+  const [quietEnd, setQuietEnd] = useState('');
+  const [nudgeText, setNudgeText] = useState('');
+  const [nudgeDelay, setNudgeDelay] = useState(0);
+  const [trackingUrl, setTrackingUrl] = useState('');
 
   const create = (e: React.FormEvent) => {
     e.preventDefault();
+    const form = new FormData();
+    form.append('message_text', message);
+    if (media) form.append('media', media);
+    form.append('category', category);
+    form.append('quiet_start', quietStart);
+    form.append('quiet_end', quietEnd);
+    form.append('nudge_text', nudgeText);
+    form.append('nudge_delay', String(nudgeDelay));
+    form.append('tracking_url', trackingUrl);
+
     fetch('/campaigns', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message_text: message })
+      body: form
     });
   };
 
   return (
     <form onSubmit={create}>
       <h2>Create Campaign</h2>
-      <textarea
-        value={message}
-        onChange={e => setMessage(e.target.value)}
-        placeholder="Message text"
-      />
+      <label>
+        Message
+        <RichTextEditor html={message} onChange={setMessage} />
+      </label>
+      <label>
+        Insert Placeholder
+        <select onChange={e => setMessage(message + ' ' + e.target.value)} defaultValue="">
+          <option value="" disabled>Select...</option>
+          {placeholders.map(p => (
+            <option key={p.value} value={p.value}>{p.label}</option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Media
+        <input type="file" onChange={e => setMedia(e.target.files?.[0] || null)} />
+      </label>
+      <label>
+        Category
+        <select value={category} onChange={e => setCategory(e.target.value)}>
+          <option value="">None</option>
+          <option value="buyer">Buyer</option>
+          <option value="browser">Browser</option>
+          <option value="refund_risk">Refund Risk</option>
+        </select>
+      </label>
+      <label>
+        Quiet Hours Start
+        <input type="time" value={quietStart} onChange={e => setQuietStart(e.target.value)} />
+      </label>
+      <label>
+        Quiet Hours End
+        <input type="time" value={quietEnd} onChange={e => setQuietEnd(e.target.value)} />
+      </label>
+      <label>
+        Nudge Text
+        <input value={nudgeText} onChange={e => setNudgeText(e.target.value)} />
+      </label>
+      <label>
+        Nudge Delay (mins)
+        <input type="number" value={nudgeDelay} onChange={e => setNudgeDelay(parseInt(e.target.value))} />
+      </label>
+      <label>
+        Tracking URL
+        <input value={trackingUrl} onChange={e => setTrackingUrl(e.target.value)} />
+      </label>
       <button type="submit">Create</button>
     </form>
   );

--- a/src/ui/CampaignMonitor.tsx
+++ b/src/ui/CampaignMonitor.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function CampaignMonitor() {
+  return (
+    <div>
+      <h2>Campaign Monitor</h2>
+      <div>Status: <span id="status">Idle</span></div>
+      <div>Errors: <span id="errors">None</span></div>
+      <div>Quiet Hours: <span id="quiet">Off</span></div>
+      <div>Nudge Status: <span id="nudge">Inactive</span></div>
+      <div>Revenue: <span id="revenue">$0</span></div>
+    </div>
+  );
+}

--- a/src/ui/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface State { hasError: boolean; }
+
+export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
+  constructor(props: React.PropsWithChildren) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/src/ui/LoginForm.tsx
+++ b/src/ui/LoginForm.tsx
@@ -1,15 +1,26 @@
 import React, { useState } from 'react';
+import { useAppState } from './Store';
 
-export default function LoginForm() {
+interface Props { onSuccess: () => void; }
+export default function LoginForm({ onSuccess }: Props) {
   const [email, setEmail] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { setToken } = useAppState();
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    setLoading(true);
     fetch('/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, api_key: apiKey })
-    }).then(r => r.json()).then(console.log);
+    })
+      .then(r => r.json())
+      .then(data => {
+        setToken(data.token);
+        onSuccess();
+      })
+      .finally(() => setLoading(false));
   };
   return (
     <form onSubmit={handleSubmit}>
@@ -24,7 +35,7 @@ export default function LoginForm() {
         value={apiKey}
         onChange={e => setApiKey(e.target.value)}
       />
-      <button type="submit">Login</button>
+      <button type="submit" disabled={loading}>{loading ? 'Loading...' : 'Login'}</button>
     </form>
   );
 }

--- a/src/ui/RichTextEditor.tsx
+++ b/src/ui/RichTextEditor.tsx
@@ -1,0 +1,24 @@
+import React, { useRef } from 'react';
+
+interface Props {
+  html: string;
+  onChange: (html: string) => void;
+}
+
+export default function RichTextEditor({ html, onChange }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleInput = () => {
+    onChange(ref.current?.innerHTML || '');
+  };
+
+  return (
+    <div
+      ref={ref}
+      contentEditable
+      onInput={handleInput}
+      dangerouslySetInnerHTML={{ __html: html }}
+      style={{ border: '1px solid #ccc', padding: '8px', minHeight: '80px' }}
+    />
+  );
+}

--- a/src/ui/SessionConnect.tsx
+++ b/src/ui/SessionConnect.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 
-export default function SessionConnect() {
+interface Props { onSuccess: () => void; }
+export default function SessionConnect({ onSuccess }: Props) {
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const sendOtp = () => {
     fetch('/session/connect', {
@@ -14,11 +16,14 @@ export default function SessionConnect() {
 
   const verify = (e: React.FormEvent) => {
     e.preventDefault();
+    setLoading(true);
     fetch('/session/verify', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ token: code })
-    });
+    })
+      .then(() => onSuccess())
+      .finally(() => setLoading(false));
   };
 
   return (
@@ -36,7 +41,7 @@ export default function SessionConnect() {
           value={code}
           onChange={e => setCode(e.target.value)}
         />
-        <button type="submit">Verify</button>
+        <button type="submit" disabled={loading}>{loading ? 'Verifying...' : 'Verify'}</button>
       </form>
     </div>
   );

--- a/src/ui/Store.tsx
+++ b/src/ui/Store.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface AppState {
+  token: string | null;
+  setToken: (t: string | null) => void;
+}
+
+const StateContext = createContext<AppState | undefined>(undefined);
+
+export const StateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(null);
+  return (
+    <StateContext.Provider value={{ token, setToken }}>
+      {children}
+    </StateContext.Provider>
+  );
+};
+
+export function useAppState() {
+  const ctx = useContext(StateContext);
+  if (!ctx) throw new Error('StateProvider missing');
+  return ctx;
+}

--- a/src/ui/client.tsx
+++ b/src/ui/client.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0 1rem;
+}
+
+nav a {
+  margin-right: 1rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+form label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+form input, form select, form textarea {
+  margin-top: 0.25rem;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/src/workers/ui.ts
+++ b/src/workers/ui.ts
@@ -14,6 +14,7 @@ app.get('/', async (c) => {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Telegram Retargeting Platform</title>
+        <link rel="stylesheet" href="/src/ui/styles.css">
       </head>
       <body>
         <div id="root">${html}</div>

--- a/tests/unit/ui/login.test.tsx
+++ b/tests/unit/ui/login.test.tsx
@@ -2,10 +2,15 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import LoginForm from '../../../src/ui/LoginForm';
+import { StateProvider } from '../../../src/ui/Store';
 
 describe('LoginForm', () => {
   it('updates fields', () => {
-    const { getByPlaceholderText } = render(<LoginForm />);
+    const { getByPlaceholderText } = render(
+      <StateProvider>
+        <LoginForm onSuccess={() => {}} />
+      </StateProvider>
+    );
     const email = getByPlaceholderText('Email') as HTMLInputElement;
     fireEvent.change(email, { target: { value: 'test' } });
     expect(email.value).toBe('test');


### PR DESCRIPTION
## Summary
- implement simple global state via `Store`
- add error boundary component
- build rich text editor and campaign monitor components
- extend campaign editor with placeholder, media, category, quiet hours, nudge, and tracking fields
- create navigation and loading states for login and session connect
- style UI with basic CSS and serve it in worker
- update analytics dashboard
- adjust tests for new provider usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852774fff68832fb2211cebd17fb99a