### PR TITLE
Implement analytics routes

### DIFF
--- a/src/workers/analytics.ts
+++ b/src/workers/analytics.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono';
+
+interface Env {
+  DB: D1Database;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get('/revenue', async c => {
+  const { results } = await c.env.DB.prepare(
+    'SELECT COALESCE(SUM(total_revenue),0) AS revenue, COALESCE(SUM(total_clicks),0) AS clicks FROM campaign_analytics'
+  ).all();
+  const row = (results as any[])[0] || { revenue: 0, clicks: 0 };
+  return c.json({ revenue: row.revenue, clicks: row.clicks, daily: [] });
+});
+
+app.get('/categories', async c => {
+  const { results } = await c.env.DB.prepare(
+    'SELECT category, COUNT(*) AS count FROM customer_categories GROUP BY category'
+  ).all();
+  const categories: Record<string, number> = {};
+  for (const r of results as any[]) {
+    categories[r.category] = r.count;
+  }
+  return c.json(categories);
+});
+
+export default app;

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -3,6 +3,7 @@ import auth from './auth';
 import session from './session';
 
 import campaigns from './campaigns';
+import analytics from './analytics';
 
 
 const app = new Hono();
@@ -11,6 +12,7 @@ app.route('/auth', auth);
 app.route('/session', session);
 
 app.route('/campaigns', campaigns);
+app.route('/analytics', analytics);
 
 
 export default app;

--- a/tests/integration/analytics.test.ts
+++ b/tests/integration/analytics.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import analytics from '../../src/workers/analytics';
+
+let app: Hono;
+
+beforeEach(() => {
+  app = new Hono();
+  app.route('/analytics', analytics);
+});
+
+function env(resultsMap: Record<string, any[]>) {
+  return {
+    DB: {
+      prepare: (sql: string) => ({
+        bind: () => ({
+          all: async () => ({ results: resultsMap[sql] || [] })
+        }),
+        all: async () => ({ results: resultsMap[sql] || [] })
+      })
+    }
+  } as any;
+}
+
+describe('analytics', () => {
+  it('returns revenue metrics', async () => {
+    const req = new Request('http://test/analytics/revenue');
+    const res = await app.fetch(req, env({
+      'SELECT COALESCE(SUM(total_revenue),0) AS revenue, COALESCE(SUM(total_clicks),0) AS clicks FROM campaign_analytics': [
+        { revenue: 5, clicks: 2 }
+      ]
+    }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.revenue).toBe(5);
+    expect(data.clicks).toBe(2);
+  });
+
+  it('returns category metrics', async () => {
+    const req = new Request('http://test/analytics/categories');
+    const res = await app.fetch(req, env({
+      'SELECT category, COUNT(*) AS count FROM customer_categories GROUP BY category': [
+        { category: 'buyer', count: 3 }
+      ]
+    }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.buyer).toBe(3);
+  });
+});

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -1,20 +1,20 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import auth from '../../src/workers/auth';
 import { Hono } from 'hono';
 
 let app: Hono;
+let db: any;
 
 beforeEach(() => {
-  global.fetch = async (url: string, init: any) => {
-    expect(init.method).toBe('POST');
-    return new Response(JSON.stringify({ results: [{ id: 1 }] }), { status: 200 });
+  db = {
+    prepare: () => ({
+      bind: () => ({
+        all: async () => ({ results: [{ id: 1 }] })
+      })
+    })
   };
   app = new Hono();
   app.route('/auth', auth);
-});
-
-afterEach(() => {
-  delete (global as any).fetch;
 });
 
 it('logs in and returns jwt', async () => {
@@ -23,8 +23,7 @@ it('logs in and returns jwt', async () => {
     body: JSON.stringify({ email: 'a', api_key: 'b' })
   });
   const res = await app.fetch(req, {
-    D1_ENDPOINT: 'http://d1',
-    D1_TOKEN: 't',
+    DB: db,
     JWT_SECRET: 'secret'
   } as any);
   expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- add analytics worker with revenue and category endpoints
- route `/analytics` in worker index
- test analytics endpoints
- adjust auth test to use DB stub

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_685faf992604832fac3ac307fcc843dd