### PR TITLE
Set production URLs and add API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ wrangler dev
 
 The worker will be available locally at `http://localhost:8787`. Set
 `VITE_API_BASE=http://localhost:8787` when running the React dev server so it
-calls the worker correctly.
+calls the worker correctly. In production the worker is hosted at
+`https://retargetting-worker.elmtalabx.workers.dev` and forwards requests to the
+Python API at
+`https://retargetting-slave-api-production.up.railway.app`.
+
+The frontend is served from `https://retargetting-revised.pages.dev`. If
+`VITE_API_BASE` is not provided, it will default to the production worker URL.
 
 ### Frontend
 ```bash
@@ -45,3 +51,14 @@ npm --prefix frontend run start
 ```
 
 The frontend provides placeholder components for editing campaigns, viewing analytics, and monitoring progress.
+
+## Testing APIs
+
+Basic connectivity tests can be run with:
+
+```bash
+./tests/run_all.sh
+```
+
+Environment variables `FRONTEND_BASE`, `WORKER_BASE` and `PYTHON_API_BASE` can
+be set to override the default production endpoints when testing locally.

--- a/frontend/src/components/ConnectTelegram.jsx
+++ b/frontend/src/components/ConnectTelegram.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
 
 
-const API_BASE = import.meta.env.VITE_API_BASE || ''
+const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  'https://retargetting-worker.elmtalabx.workers.dev'
 
 
 export default function ConnectTelegram() {

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Simple script to run API tests
+
+python3 tests/test_endpoints.py

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,33 @@
+import os
+import requests
+
+FRONTEND_BASE = os.environ.get('FRONTEND_BASE', 'https://retargetting-revised.pages.dev')
+WORKER_BASE = os.environ.get('WORKER_BASE', 'https://retargetting-worker.elmtalabx.workers.dev')
+PYTHON_API_BASE = os.environ.get('PYTHON_API_BASE', 'https://retargetting-slave-api-production.up.railway.app')
+
+
+def check(url: str, method='get', **kwargs):
+    print(f"Testing {url}")
+    try:
+        resp = requests.request(method, url, timeout=10, **kwargs)
+        print(f"  Status: {resp.status_code}")
+        print(f"  Body: {resp.text[:200]}")
+        return resp.status_code
+    except Exception as e:
+        print(f"  Error: {e}")
+        return None
+
+
+if __name__ == '__main__':
+    # Python API health
+    check(f"{PYTHON_API_BASE}/health")
+
+    # Worker session connect with fake phone (expect failure but endpoint reachable)
+    check(
+        f"{WORKER_BASE}/session/connect",
+        method='post',
+        json={'phone': '+10000000000'}
+    )
+
+    # Frontend main page
+    check(FRONTEND_BASE)

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 command = "npm run build"
 
 [vars]
-PYTHON_API_URL = "http://localhost:5000"
+PYTHON_API_URL = "https://retargetting-slave-api-production.up.railway.app"
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- configure worker to contact the production Python API
- default frontend requests to the deployed worker URL
- document production URLs and testing instructions in README
- add simple scripts for exercising endpoints

## Testing
- `python -m py_compile python_api/app.py`
- `npm --prefix worker install`
- `npm --prefix worker run build`
- `npm --prefix frontend install`
- `npm --prefix frontend run build`
- `./tests/run_all.sh` *(fails: connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6863faa9b0a4832f9a2018ae6c1b4984