### PR TITLE
Implement basic category manager

### DIFF
--- a/frontend/src/components/CategoryManager.jsx
+++ b/frontend/src/components/CategoryManager.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react'
+
+const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  'https://retargetting-worker.elmtalabx.workers.dev'
+
+export default function CategoryManager() {
+  const [categories, setCategories] = useState([])
+  const [name, setName] = useState('')
+  const [keywords, setKeywords] = useState('')
+  const [status, setStatus] = useState('')
+
+  const fetchCategories = async () => {
+    try {
+      const resp = await fetch(`${API_BASE}/categories`)
+      const data = await resp.json()
+      setCategories(data.categories || [])
+    } catch (err) {
+      console.error('fetch categories', err)
+    }
+  }
+
+  useEffect(() => {
+    fetchCategories()
+  }, [])
+
+  const submit = async e => {
+    e.preventDefault()
+    setStatus('Saving...')
+    try {
+      const resp = await fetch(`${API_BASE}/categories`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, keywords: keywords.split(',').map(k => k.trim()).filter(k => k) })
+      })
+      const data = await resp.json()
+      if (!resp.ok) throw new Error(JSON.stringify(data))
+      setStatus('Saved')
+      setName('')
+      setKeywords('')
+      fetchCategories()
+    } catch (err) {
+      console.error('create category', err)
+      setStatus('Failed')
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-2xl mb-2 font-semibold">Categories</h2>
+      <form onSubmit={submit} className="space-y-2 bg-white p-4 rounded shadow max-w-md">
+        <input
+          type="text"
+          placeholder="Category name"
+          className="border p-2 w-full"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Keywords (comma separated)"
+          className="border p-2 w-full"
+          value={keywords}
+          onChange={e => setKeywords(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded">Add</button>
+        {status && <p className="text-sm text-gray-600">{status}</p>}
+      </form>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {categories.map(c => (
+          <div key={c.id} className="bg-white p-3 rounded shadow">
+            <h3 className="font-medium mb-1">{c.name}</h3>
+            <p className="text-sm text-gray-600">
+              {(JSON.parse(c.keywords_json || '[]')).join(', ')}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -4,6 +4,7 @@ import CampaignEditor from './CampaignEditor'
 import AnalyticsDashboard from './AnalyticsDashboard'
 import CampaignMonitor from './CampaignMonitor'
 import ConnectTelegram from './ConnectTelegram'
+import CategoryManager from './CategoryManager'
 
 export default function MainPage({ onLogout }) {
   return (
@@ -45,6 +46,16 @@ export default function MainPage({ onLogout }) {
           </li>
           <li>
             <NavLink
+              to="/categories"
+              className={({ isActive }) =>
+                `block px-2 py-1 rounded ${isActive ? 'bg-blue-500 text-white' : 'text-blue-600'}`
+              }
+            >
+              Categories
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
               to="/connect"
               className={({ isActive }) =>
                 `block px-2 py-1 rounded ${isActive ? 'bg-blue-500 text-white' : 'text-blue-600'}`
@@ -66,6 +77,7 @@ export default function MainPage({ onLogout }) {
           <Route path="/analytics" element={<AnalyticsDashboard />} />
           <Route path="/monitor" element={<CampaignMonitor />} />
           <Route path="/connect" element={<ConnectTelegram />} />
+          <Route path="/categories" element={<CategoryManager />} />
         </Routes>
       </main>
     </div>

--- a/python_api/app.py
+++ b/python_api/app.py
@@ -132,5 +132,23 @@ def session_verify():
     print('API verify success', session_final[:10])
     return jsonify({'session': session_final})
 
+
+@app.route('/classify', methods=['POST'])
+def classify_text():
+    """Classify text based on provided categories and keywords."""
+    data = request.get_json(force=True)
+    text = data.get('text', '')
+    categories = data.get('categories', [])
+    text_lower = text.lower()
+    matched = []
+    for cat in categories:
+        name = cat.get('name')
+        kws = cat.get('keywords', [])
+        for kw in kws:
+            if kw.lower() in text_lower:
+                matched.append(name)
+                break
+    return jsonify({'matches': matched})
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/worker/db/schema.sql
+++ b/worker/db/schema.sql
@@ -45,6 +45,15 @@ CREATE TABLE customer_categories (
     FOREIGN KEY (account_id) REFERENCES accounts(id)
 );
 
+-- Definitions for available customer categories
+CREATE TABLE categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id INTEGER NOT NULL,
+    name TEXT,
+    keywords_json TEXT,
+    FOREIGN KEY (account_id) REFERENCES accounts(id)
+);
+
 CREATE TABLE trackable_links (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     campaign_id INTEGER NOT NULL,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -140,6 +140,33 @@ router.post('/campaigns/:id/start', async ({ params }) => {
   })
 })
 
+// List categories
+router.get('/categories', async (request: Request, env: Env) => {
+  const accountId = 1
+  const { results } = await env.DB.prepare(
+    'SELECT id, name, keywords_json FROM categories WHERE account_id=?1'
+  )
+    .bind(accountId)
+    .all<any>()
+  return new Response(JSON.stringify({ categories: results }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+})
+
+// Create category
+router.post('/categories', async (request: Request, env: Env) => {
+  const { name, keywords } = await request.json()
+  const accountId = 1
+  const res = await env.DB.prepare(
+    'INSERT INTO categories (account_id, name, keywords_json) VALUES (?1, ?2, ?3)'
+  )
+    .bind(accountId, name, JSON.stringify(keywords || []))
+    .run()
+  return new Response(JSON.stringify({ id: res.lastRowId }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+})
+
 // Default route
 router.all('*', () => new Response('Not Found', { status: 404 }))
 


### PR DESCRIPTION
## Summary
- add DB table for categories
- add worker endpoints for creating and listing categories
- implement simple keyword-based category classification endpoint in Python API
- add new CategoryManager React component
- wire category manager into MainPage navigation

## Testing
- `npm --prefix frontend install`
- `bash tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68641e42e04c832f9813b56487a187db