### PR TITLE
Persist Telegram sessions for logged-in users

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,11 +3,33 @@ import Login from './components/Login'
 import MainPage from './components/MainPage'
 
 export default function App() {
-  const [loggedIn, setLoggedIn] = useState(false)
+  const [accountId, setAccountId] = useState(() => localStorage.getItem('accountId'))
+  const [sessionId, setSessionId] = useState(() => localStorage.getItem('sessionId'))
 
-  if (!loggedIn) {
-    return <Login onLogin={() => setLoggedIn(true)} />
+  const handleLogin = id => {
+    console.log('App login', id)
+    setAccountId(id)
+    localStorage.setItem('accountId', id)
   }
 
-  return <MainPage onLogout={() => setLoggedIn(false)} />
+  const handleLogout = () => {
+    console.log('App logout')
+    setAccountId(null)
+    setSessionId(null)
+    localStorage.removeItem('accountId')
+    localStorage.removeItem('sessionId')
+  }
+
+  if (!accountId) {
+    return <Login onLogin={handleLogin} />
+  }
+
+  const handleSelectSession = id => {
+    console.log('App selected session', id)
+    setSessionId(id)
+    if (id) localStorage.setItem('sessionId', id)
+    else localStorage.removeItem('sessionId')
+  }
+
+  return <MainPage accountId={accountId} sessionId={sessionId} onSelectSession={handleSelectSession} onLogout={handleLogout} />
 }

--- a/frontend/src/components/AnalyticsDashboard.jsx
+++ b/frontend/src/components/AnalyticsDashboard.jsx
@@ -23,7 +23,7 @@ Chart.register(
   Legend
 )
 
-export default function AnalyticsDashboard() {
+export default function AnalyticsDashboard({ accountId, sessionId }) {
   const API_BASE =
     import.meta.env.VITE_API_BASE ||
     'https://retargetting-worker.elmtalabx.workers.dev'
@@ -35,11 +35,13 @@ export default function AnalyticsDashboard() {
   const [topLines, setTopLines] = useState([])
 
   useEffect(() => {
-    console.log('AnalyticsDashboard mounted')
+    console.log('AnalyticsDashboard mounted', accountId, sessionId)
     const fetchData = async () => {
       try {
         console.log('Fetching analytics summary...')
-        const resp = await fetch(`${API_BASE}/analytics/summary`)
+        const url = `${API_BASE}/analytics/summary?account_id=${accountId}&session_id=${sessionId || ''}`
+        console.log('fetching', url)
+        const resp = await fetch(url)
         console.log('Fetch response:', resp)
         const data = await resp.json()
         console.log('Fetched data:', data)
@@ -123,7 +125,7 @@ export default function AnalyticsDashboard() {
       }
     }
     fetchData()
-  }, [])
+  }, [accountId, sessionId])
 
   useEffect(() => {
     console.log('metrics state updated:', metrics)

--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react'
 
-export default function CampaignMonitor() {
+export default function CampaignMonitor({ sessionId }) {
   const [progress, setProgress] = useState(0)
   const [errors, setErrors] = useState([])
   const [logs, setLogs] = useState([])
 
   // mock progress simulation
   useEffect(() => {
+    console.log('CampaignMonitor mount session', sessionId)
     const id = setInterval(() => {
       setProgress(p => {
         const next = p < 100 ? p + 5 : 100

--- a/frontend/src/components/ConnectTelegram.jsx
+++ b/frontend/src/components/ConnectTelegram.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 
 const API_BASE =
@@ -10,11 +10,32 @@ console.log('Using API base', API_BASE)
 
 
 
-export default function ConnectTelegram() {
-  const [step, setStep] = useState('phone')
+export default function ConnectTelegram({ accountId, sessionId, onSelectSession }) {
+  const [step, setStep] = useState('list')
   const [phone, setPhone] = useState('')
   const [code, setCode] = useState('')
   const [status, setStatus] = useState('')
+  const [sessions, setSessions] = useState([])
+
+  const fetchSessions = () => {
+    console.log('fetching sessions for', accountId)
+    fetch(`${API_BASE}/session/status?account_id=${accountId}`)
+      .then(r => r.json())
+      .then(d => {
+        console.log('session status data', d)
+        setSessions(d.sessions || [])
+        if ((d.sessions || []).length > 0) {
+          setStep('list')
+        } else {
+          setStep('phone')
+        }
+      })
+      .catch(e => console.error('status error', e))
+  }
+
+  useEffect(() => {
+    fetchSessions()
+  }, [accountId])
 
   const sendPhone = async e => {
     e.preventDefault()
@@ -23,10 +44,9 @@ export default function ConnectTelegram() {
       console.log('frontend sending phone', phone)
 
       const resp = await fetch(`${API_BASE}/session/connect`, {
-
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone }),
+        body: JSON.stringify({ phone, account_id: accountId }),
       })
 
       console.log('frontend connect status', resp.status)
@@ -49,10 +69,9 @@ export default function ConnectTelegram() {
       console.log('frontend verifying code', code)
 
       const resp = await fetch(`${API_BASE}/session/verify`, {
-
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone, code }),
+        body: JSON.stringify({ phone, code, account_id: accountId }),
       })
 
       console.log('frontend verify status', resp.status)
@@ -60,8 +79,11 @@ export default function ConnectTelegram() {
       console.log('frontend verify body', data)
       if (!resp.ok) throw new Error(JSON.stringify(data))
 
-      console.log('frontend verify success')
+      console.log('frontend verify success', data)
       setStatus('Account connected!')
+      fetchSessions()
+      onSelectSession && onSelectSession(data.session_id)
+      setStep('list')
     } catch (err) {
       console.error('frontend verify error', err)
       setStatus('Verification failed')
@@ -71,6 +93,28 @@ export default function ConnectTelegram() {
   return (
     <div className="p-4 max-w-md mx-auto space-y-4">
       <h2 className="text-2xl font-semibold text-center">Connect Telegram</h2>
+      {step === 'list' && (
+        <div className="space-y-2">
+          <p className="text-sm">Select a session:</p>
+          <ul className="space-y-1">
+            {sessions.map(s => (
+              <li key={s.id} className="flex items-center justify-between border p-2 rounded">
+                <span>{s.phone || 'Session ' + s.id}</span>
+                <button
+                  className="text-sm underline"
+                  onClick={() => {
+                    console.log('select session', s.id)
+                    onSelectSession && onSelectSession(s.id)
+                  }}
+                >
+                  {sessionId == s.id ? 'Selected' : 'Use'}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button className="text-sm underline" onClick={() => setStep('phone')}>Add New Session</button>
+        </div>
+      )}
       {step === 'phone' && (
         <form onSubmit={sendPhone} className="space-y-2">
           <input
@@ -104,6 +148,9 @@ export default function ConnectTelegram() {
             Verify
           </button>
         </form>
+      )}
+      {step === 'done' && (
+        <p className="text-center">Telegram already connected.</p>
       )}
       {status && <p className="text-center text-sm text-gray-600">{status}</p>}
     </div>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,12 +1,36 @@
 import React, { useState } from 'react'
 
+const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  'https://retargetting-worker.elmtalabx.workers.dev'
+
 export default function Login({ onLogin }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [mode, setMode] = useState('login')
+  const [status, setStatus] = useState('')
 
-  const handleSubmit = e => {
+  const handleSubmit = async e => {
     e.preventDefault()
-    onLogin()
+    setStatus(mode === 'signup' ? 'Signing up...' : 'Logging in...')
+    try {
+      console.log('login form submit', mode, email)
+      const resp = await fetch(`${API_BASE}/auth/${mode}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const data = await resp.json().catch(() => ({}))
+      console.log('auth response', resp.status, data)
+      if (!resp.ok) throw new Error(JSON.stringify(data))
+      const id = data.id
+      localStorage.setItem('accountId', id)
+      setStatus('Success')
+      onLogin(id)
+    } catch (err) {
+      console.error('auth error', err)
+      setStatus('Failed')
+    }
   }
 
   return (
@@ -15,7 +39,7 @@ export default function Login({ onLogin }) {
         onSubmit={handleSubmit}
         className="flex flex-col bg-white p-8 rounded shadow gap-4 w-80"
       >
-        <h1 className="text-xl font-semibold text-center">Login</h1>
+        <h1 className="text-xl font-semibold text-center">{mode === 'signup' ? 'Sign Up' : 'Login'}</h1>
         <input
           type="text"
           placeholder="Email"
@@ -34,8 +58,16 @@ export default function Login({ onLogin }) {
           type="submit"
           className="bg-blue-600 text-white py-2 rounded"
         >
-          Log In
+          {mode === 'signup' ? 'Sign Up' : 'Log In'}
         </button>
+        <button
+          type="button"
+          onClick={() => setMode(mode === 'signup' ? 'login' : 'signup')}
+          className="text-sm underline"
+        >
+          {mode === 'signup' ? 'Have an account? Login' : 'Need an account? Sign Up'}
+        </button>
+        {status && <p className="text-sm text-center">{status}</p>}
       </form>
     </div>
   )

--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -6,7 +6,7 @@ import CampaignMonitor from './CampaignMonitor'
 import ConnectTelegram from './ConnectTelegram'
 import CategoryManager from './CategoryManager'
 
-export default function MainPage({ onLogout }) {
+export default function MainPage({ onLogout, accountId, sessionId, onSelectSession }) {
   return (
     <div className="flex h-screen">
       <aside className="w-64 bg-gray-100 p-6 space-y-4">
@@ -91,9 +91,9 @@ export default function MainPage({ onLogout }) {
         <Routes>
           <Route path="/" element={<Navigate to="/editor" replace />} />
           <Route path="/editor" element={<CampaignEditor />} />
-          <Route path="/analytics" element={<AnalyticsDashboard />} />
-          <Route path="/monitor" element={<CampaignMonitor />} />
-          <Route path="/connect" element={<ConnectTelegram />} />
+          <Route path="/analytics" element={<AnalyticsDashboard accountId={accountId} sessionId={sessionId} />} />
+          <Route path="/monitor" element={<CampaignMonitor sessionId={sessionId} />} />
+          <Route path="/connect" element={<ConnectTelegram accountId={accountId} sessionId={sessionId} onSelectSession={onSelectSession} />} />
           <Route path="/categories" element={<CategoryManager />} />
         </Routes>
       </main>

--- a/worker/db/schema.sql
+++ b/worker/db/schema.sql
@@ -3,23 +3,27 @@
 CREATE TABLE accounts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     email TEXT NOT NULL UNIQUE,
-    api_key TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
     plan_type TEXT
 );
 
 CREATE TABLE campaigns (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     account_id INTEGER NOT NULL,
+    telegram_session_id INTEGER,
     message_text TEXT,
     status TEXT,
     filters_json TEXT,
     quiet_hours_json TEXT,
     nudge_settings_json TEXT,
-    FOREIGN KEY (account_id) REFERENCES accounts(id)
+    FOREIGN KEY (account_id) REFERENCES accounts(id),
+    FOREIGN KEY (telegram_session_id) REFERENCES telegram_sessions(id)
 );
 
 CREATE TABLE telegram_sessions (
-    account_id INTEGER PRIMARY KEY,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id INTEGER NOT NULL,
+    phone TEXT,
     encrypted_session_data TEXT,
     FOREIGN KEY (account_id) REFERENCES accounts(id)
 );

--- a/worker/db/seed.sql
+++ b/worker/db/seed.sql
@@ -1,9 +1,14 @@
-INSERT INTO accounts (id, email, api_key, plan_type) VALUES
-  (1, 'demo@example.com', 'demo_key', 'free');
+INSERT INTO accounts (id, email, password_hash, plan_type) VALUES
+  (1, 'demo@example.com', 'demo', 'free');
 
 INSERT INTO campaigns (id, account_id, message_text, status, filters_json, quiet_hours_json, nudge_settings_json)
 VALUES
   (1, 1, 'Hello {{first_name}}, check out our sale!', 'completed', '{}', '{}', '{}');
+
+INSERT INTO telegram_sessions (id, account_id, phone, encrypted_session_data)
+VALUES (1, 1, '+10000000000', 'dummy');
+
+UPDATE campaigns SET telegram_session_id=1 WHERE id=1;
 
 -- Some sent logs for analytics
 INSERT INTO sent_logs (account_id, campaign_id, user_phone, status, error_details)

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -21,21 +21,25 @@ const INIT_SCHEMA = `
 CREATE TABLE IF NOT EXISTS accounts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     email TEXT NOT NULL UNIQUE,
-    api_key TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
     plan_type TEXT
 );
 CREATE TABLE IF NOT EXISTS campaigns (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     account_id INTEGER NOT NULL,
+    telegram_session_id INTEGER,
     message_text TEXT,
     status TEXT,
     filters_json TEXT,
     quiet_hours_json TEXT,
     nudge_settings_json TEXT,
-    FOREIGN KEY (account_id) REFERENCES accounts(id)
+    FOREIGN KEY (account_id) REFERENCES accounts(id),
+    FOREIGN KEY (telegram_session_id) REFERENCES telegram_sessions(id)
 );
 CREATE TABLE IF NOT EXISTS telegram_sessions (
-    account_id INTEGER PRIMARY KEY,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id INTEGER NOT NULL,
+    phone TEXT,
     encrypted_session_data TEXT,
     FOREIGN KEY (account_id) REFERENCES accounts(id)
 );
@@ -104,19 +108,62 @@ async function ensureSchema(db: D1Database) {
   }
 }
 
-// Authentication - placeholder
-router.post('/auth/login', async (request: Request) => {
-  // TODO: implement JWT issuance
-  return new Response(JSON.stringify({ token: 'TODO' }), {
-    headers: { 'Content-Type': 'application/json' },
-  })
+async function hashPassword(pw: string): Promise<string> {
+  const enc = new TextEncoder();
+  const buf = await crypto.subtle.digest('SHA-256', enc.encode(pw));
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// Sign up new account
+router.post('/auth/signup', async (request: Request, env: Env) => {
+  const { email, password } = await request.json() as any
+  console.log('POST /auth/signup', email)
+  if (!email || !password) {
+    return new Response(JSON.stringify({ error: 'missing parameters' }), { status: 400 })
+  }
+  const hash = await hashPassword(password)
+  try {
+    const res = await env.DB.prepare(
+      'INSERT INTO accounts (email, password_hash, plan_type) VALUES (?1, ?2, ?3)'
+    ).bind(email, hash, 'basic').run()
+    console.log('created account id', res.lastRowId)
+    return new Response(JSON.stringify({ id: res.lastRowId }), { headers: { 'Content-Type': 'application/json' } })
+  } catch (err) {
+    console.error('/auth/signup error', err)
+    return new Response(JSON.stringify({ error: 'account exists' }), { status: 400 })
+  }
+})
+
+// Authentication - simple login
+router.post('/auth/login', async (request: Request, env: Env) => {
+  const { email, password } = await request.json() as any
+  console.log('POST /auth/login', email)
+  if (!email || !password) {
+    return new Response(JSON.stringify({ error: 'missing parameters' }), { status: 400 })
+  }
+  const hash = await hashPassword(password)
+  const row = await env.DB.prepare('SELECT id, password_hash FROM accounts WHERE email=?1')
+    .bind(email)
+    .first()
+  if (row && row.password_hash === hash) {
+    console.log('login success for account', row.id)
+    return new Response(JSON.stringify({ id: row.id }), { headers: { 'Content-Type': 'application/json' } })
+  } else {
+    console.log('login failed for', email)
+    return new Response(JSON.stringify({ error: 'invalid credentials' }), { status: 401 })
+  }
 })
 
 // Begin Telegram session - send code
 router.post('/session/connect', async (request: Request, env: Env) => {
-  const { phone } = await request.json() as any
-  console.log('worker /session/connect phone', phone)
-  const accountId = 1
+  const { phone, account_id } = await request.json() as any
+  console.log('worker /session/connect phone', phone, 'account', account_id)
+  const accountId = Number(account_id || 0)
+  if (!accountId) {
+    return new Response(JSON.stringify({ error: 'account_id required' }), { status: 400 })
+  }
 
   let resp
   try {
@@ -163,11 +210,14 @@ router.post('/session/connect', async (request: Request, env: Env) => {
 
 // Verify telegram login code
 router.post('/session/verify', async (request: Request, env: Env) => {
-  const { phone, code } = await request.json() as any
-  console.log('worker /session/verify phone', phone, 'code', code)
-  const accountId = 1
+  const { phone, code, account_id } = await request.json() as any
+  console.log('worker /session/verify phone', phone, 'code', code, 'account', account_id)
+  const accountId = Number(account_id || 0)
+  if (!accountId) {
+    return new Response('account_id required', { status: 400 })
+  }
   const row = await env.DB.prepare(
-    'SELECT session, phone_code_hash FROM pending_sessions WHERE account_id=?1'
+    'SELECT phone, session, phone_code_hash FROM pending_sessions WHERE account_id=?1'
   )
     .bind(accountId)
     .first()
@@ -209,19 +259,37 @@ router.post('/session/verify', async (request: Request, env: Env) => {
     return new Response(JSON.stringify(data), { status: resp.status })
   }
 
-  await env.DB.prepare(
-    'INSERT OR REPLACE INTO telegram_sessions (account_id, encrypted_session_data) VALUES (?1, ?2)'
+  const insertRes = await env.DB.prepare(
+    'INSERT INTO telegram_sessions (account_id, phone, encrypted_session_data) VALUES (?1, ?2, ?3)'
   )
-    .bind(accountId, (data as any).session)
+    .bind(accountId, row.phone, (data as any).session)
     .run()
+  const newSessionId = insertRes.lastRowId
+  console.log('stored session id', newSessionId)
 
   await env.DB.prepare('DELETE FROM pending_sessions WHERE account_id=?1')
     .bind(accountId)
     .run()
 
-  return new Response(JSON.stringify({ status: 'connected' }), {
+  return new Response(JSON.stringify({ status: 'connected', session_id: newSessionId }), {
     headers: { 'Content-Type': 'application/json' }
   })
+})
+
+// Check if a telegram session exists for the account
+router.get('/session/status', async (request: Request, env: Env) => {
+  const url = new URL(request.url)
+  const accountId = Number(url.searchParams.get('account_id') || 0)
+  console.log('GET /session/status account', accountId)
+  if (!accountId) {
+    return new Response(JSON.stringify({ error: 'account_id required' }), { status: 400 })
+  }
+  const { results } = await env.DB.prepare(
+    'SELECT id, phone FROM telegram_sessions WHERE account_id=?1'
+  ).bind(accountId).all()
+  const sessions = Array.isArray(results) ? results : results.results || []
+  console.log('session list', sessions)
+  return new Response(JSON.stringify({ sessions }), { headers: { 'Content-Type': 'application/json' } })
 })
 
 // Campaign creation placeholder
@@ -281,40 +349,42 @@ router.post('/categories', async (request: Request, env: Env) => {
 
 // Analytics summary
 router.get('/analytics/summary', async (request: Request, env: Env) => {
-  const accountId = 1
-
-  console.log('GET /analytics/summary account', accountId)
+  const url = new URL(request.url)
+  const accountId = Number(url.searchParams.get('account_id') || 0)
+  const sessionId = Number(url.searchParams.get('session_id') || 0)
+  
+  console.log('GET /analytics/summary account', accountId, 'session', sessionId)
   try {
     const totalRow = await env.DB.prepare(
-      'SELECT COUNT(*) as cnt FROM sent_logs WHERE account_id=?1'
+      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
     )
-      .bind(accountId)
+      .bind(accountId, sessionId)
       .first()
     console.log('totalRow', totalRow)
 
     const successRow = await env.DB.prepare(
-      "SELECT COUNT(*) as cnt FROM sent_logs WHERE account_id=?1 AND status='sent'"
+      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1 AND s.status='sent'${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
     )
-      .bind(accountId)
+      .bind(accountId, sessionId)
       .first()
     console.log('successRow', successRow)
 
     const failRow = await env.DB.prepare(
-      "SELECT COUNT(*) as cnt FROM sent_logs WHERE account_id=?1 AND status!='sent'"
+      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1 AND s.status!='sent'${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
     )
-      .bind(accountId)
+      .bind(accountId, sessionId)
       .first()
     console.log('failRow', failRow)
 
     const revenueRow = await env.DB.prepare(
-      'SELECT SUM(revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1'
+      `SELECT SUM(revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
     )
-      .bind(accountId)
+      .bind(accountId, sessionId)
       .first()
     console.log('revenueRow', revenueRow)
 
     const categoryRowsResult = await env.DB.prepare(
-      'SELECT category, COUNT(*) as count FROM customer_categories WHERE account_id=?1 GROUP BY category'
+      `SELECT category, COUNT(*) as count FROM customer_categories WHERE account_id=?1 GROUP BY category`
     )
       .bind(accountId)
       .all()
@@ -322,9 +392,9 @@ router.get('/analytics/summary', async (request: Request, env: Env) => {
     console.log('categoryRows', categoryRows)
 
     const campaignRowsResult = await env.DB.prepare(
-      'SELECT c.id, c.message_text, COALESCE(a.total_sent,0) as total_sent FROM campaigns c LEFT JOIN campaign_analytics a ON c.id=a.campaign_id WHERE c.account_id=?1'
+      `SELECT c.id, c.message_text, COALESCE(a.total_sent,0) as total_sent, c.telegram_session_id FROM campaigns c LEFT JOIN campaign_analytics a ON c.id=a.campaign_id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
     )
-      .bind(accountId)
+      .bind(accountId, sessionId)
       .all()
     const campaignRows = Array.isArray(campaignRowsResult) ? campaignRowsResult : campaignRowsResult.results || []
     console.log('campaignRows', campaignRows)
@@ -332,9 +402,9 @@ router.get('/analytics/summary', async (request: Request, env: Env) => {
     let revenueDayRows = []
     try {
       revenueDayRows = await env.DB.prepare(
-        'SELECT strftime("%Y-%m-%d", tl.created_at) as day, SUM(tl.revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1 GROUP BY day ORDER BY day'
+        `SELECT strftime("%Y-%m-%d", tl.created_at) as day, SUM(tl.revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''} GROUP BY day ORDER BY day`
       )
-        .bind(accountId)
+        .bind(accountId, sessionId)
         .all()
       if (!Array.isArray(revenueDayRows)) revenueDayRows = []
     } catch (e) {


### PR DESCRIPTION
## Summary
- add telegram_session_id column and store multiple sessions
- track sessions by account and expose session list in API
- store selected session in frontend and allow switching
- pass session id to analytics and monitor components
- support session-aware analytics queries

## Testing
- `npm --prefix worker install`
- `pip install -r python_api/requirements.txt`
- `bash tests/run_all.sh` *(fails: 404 on classify and Telegram banned errors)*

------
https://chatgpt.com/codex/tasks/task_e_686673b7f3ec832f9cad45d1ec5b8318