### PR TITLE
Improve monitoring and campaign editor

### DIFF
--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -7,6 +7,7 @@ import ConnectTelegram from './ConnectTelegram'
 import CategoryManager from './CategoryManager'
 
 export default function MainPage({ onLogout, accountId, sessionId, onSelectSession }) {
+  const [campaignId, setCampaignId] = React.useState(null)
   return (
     <div className="flex h-screen">
       <aside className="w-64 bg-gray-100 p-6 space-y-4">
@@ -90,9 +91,9 @@ export default function MainPage({ onLogout, accountId, sessionId, onSelectSessi
       <main className="flex-1 p-4 overflow-auto">
         <Routes>
           <Route path="/" element={<Navigate to="/editor" replace />} />
-          <Route path="/editor" element={<CampaignEditor />} />
+          <Route path="/editor" element={<CampaignEditor accountId={accountId} sessionId={sessionId} onSelectCampaign={setCampaignId} />} />
           <Route path="/analytics" element={<AnalyticsDashboard accountId={accountId} sessionId={sessionId} />} />
-          <Route path="/monitor" element={<CampaignMonitor sessionId={sessionId} />} />
+          <Route path="/monitor" element={<CampaignMonitor campaignId={campaignId} />} />
           <Route path="/connect" element={<ConnectTelegram accountId={accountId} sessionId={sessionId} onSelectSession={onSelectSession} />} />
           <Route path="/categories" element={<CategoryManager />} />
         </Routes>


### PR DESCRIPTION
## Summary
- capture per-campaign logs in the Python API and expose via new endpoint
- extend worker routes to list campaigns and fetch logs
- enhance campaign editor with validation, run button and draft list
- update monitor to display real message logs
- wire new props through `MainPage`

## Testing
- `tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68669d39b95c832f8ac2a0b6d83c78da