### PR TITLE
Improve campaign monitoring UI

### DIFF
--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -4,15 +4,37 @@ const API_BASE =
   import.meta.env.VITE_API_BASE ||
   'https://retargetting-worker.elmtalabx.workers.dev'
 
-export default function CampaignMonitor({ campaignId }) {
+export default function CampaignMonitor({ accountId, campaignId, onSelectCampaign }) {
   const [progress, setProgress] = useState(0)
   const [errors, setErrors] = useState([])
   const [logs, setLogs] = useState([])
+  const [running, setRunning] = useState([])
+  const [activeId, setActiveId] = useState(campaignId || null)
 
   useEffect(() => {
-    if (!campaignId) return
+    setActiveId(campaignId || null)
+  }, [campaignId])
+
+  useEffect(() => {
+    if (!accountId) return
+    const fetchRunning = () => {
+      fetch(`${API_BASE}/campaigns?account_id=${accountId}`)
+        .then(r => r.json())
+        .then(d => {
+          const arr = (d.campaigns || []).filter(c => c.status === 'running')
+          setRunning(arr)
+        })
+        .catch(e => console.error('fetch running campaigns', e))
+    }
+    fetchRunning()
+    const id = setInterval(fetchRunning, 5000)
+    return () => clearInterval(id)
+  }, [accountId])
+
+  useEffect(() => {
+    if (!activeId) return
     const fetchLogs = () => {
-      fetch(`${API_BASE}/campaigns/${campaignId}/logs`)
+      fetch(`${API_BASE}/campaigns/${activeId}/logs`)
         .then(r => r.json())
         .then(d => {
           const arr = d.logs || []
@@ -28,7 +50,7 @@ export default function CampaignMonitor({ campaignId }) {
     fetchLogs()
     const id = setInterval(fetchLogs, 2000)
     return () => clearInterval(id)
-  }, [campaignId])
+  }, [activeId])
 
   return (
 
@@ -36,63 +58,92 @@ export default function CampaignMonitor({ campaignId }) {
       <h2 className="text-2xl mb-2 font-semibold">Campaign Monitor</h2>
 
       <div>
-        <h3 className="font-medium mb-1">Live Sending Status</h3>
-        <div className="w-full bg-gray-200 h-4 rounded overflow-hidden">
-          <div
-            className="bg-green-500 h-full transition-all"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-        <p className="text-sm mt-1">{progress}% complete</p>
-      </div>
-
-      <div>
-        <h3 className="font-medium mb-1">Error Notifications</h3>
-        {errors.length === 0 ? (
-          <p className="text-sm text-gray-500">No errors</p>
+        <h3 className="font-medium mb-1">Running Campaigns</h3>
+        {running.length === 0 ? (
+          <p className="text-sm text-gray-500">No campaigns running</p>
         ) : (
-          <ul className="list-disc list-inside text-sm text-red-600 space-y-1">
-            {errors.map((e, i) => (
-              <li key={i}>{e}</li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <h3 className="font-medium">Quiet Hours:</h3>
-        <span className="px-2 py-1 bg-yellow-200 text-yellow-800 rounded text-sm">
-          Off
-        </span>
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <h3 className="font-medium">Nudge Status:</h3>
-        <span className="px-2 py-1 bg-blue-200 text-blue-800 rounded text-sm">
-          Waiting
-        </span>
-      </div>
-
-      <div className="text-sm">
-        <h3 className="font-medium">Revenue Generated</h3>
-        <p>$123.45</p>
-      </div>
-
-      <div>
-        <h3 className="font-medium mb-1">Live Logs</h3>
-        {logs.length === 0 ? (
-          <p className="text-sm text-gray-500">No logs yet</p>
-        ) : (
-          <ul className="text-sm list-disc list-inside space-y-1">
-            {logs.map((l, i) => (
-              <li key={i}>
-                {l.phone}: {l.status}
-                {l.error && ` - ${l.error}`}
+          <ul className="space-y-1">
+            {running.map(c => (
+              <li
+                key={c.id}
+                onClick={() => {
+                  setActiveId(c.id)
+                  onSelectCampaign && onSelectCampaign(c.id)
+                }}
+                className={`cursor-pointer p-2 border rounded ${c.id === activeId ? 'bg-blue-50 border-blue-300' : 'hover:bg-gray-50'}`}
+              >
+                <p className="text-sm font-medium">#{c.id}</p>
+                <p className="text-xs text-gray-600">{c.message_text.slice(0, 60)}...</p>
               </li>
             ))}
           </ul>
         )}
       </div>
+
+      {activeId && (
+        <div className="flex flex-col md:flex-row gap-6 border rounded p-4 bg-white shadow">
+          <div className="flex-1 space-y-4">
+            <div>
+              <h3 className="font-medium mb-1">Live Sending Status</h3>
+              <div className="w-full bg-gray-200 h-4 rounded overflow-hidden">
+                <div
+                  className="bg-green-500 h-full transition-all"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <p className="text-sm mt-1">{progress}% complete</p>
+            </div>
+
+            <div>
+              <h3 className="font-medium mb-1">Error Notifications</h3>
+              {errors.length === 0 ? (
+                <p className="text-sm text-gray-500">No errors</p>
+              ) : (
+                <ul className="list-disc list-inside text-sm text-red-600 space-y-1">
+                  {errors.map((e, i) => (
+                    <li key={i}>{e}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <h3 className="font-medium">Quiet Hours:</h3>
+              <span className="px-2 py-1 bg-yellow-200 text-yellow-800 rounded text-sm">
+                Off
+              </span>
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <h3 className="font-medium">Nudge Status:</h3>
+              <span className="px-2 py-1 bg-blue-200 text-blue-800 rounded text-sm">
+                Waiting
+              </span>
+            </div>
+
+            <div className="text-sm">
+              <h3 className="font-medium">Revenue Generated</h3>
+              <p>$123.45</p>
+            </div>
+
+            <div>
+              <h3 className="font-medium mb-1">Live Logs</h3>
+              {logs.length === 0 ? (
+                <p className="text-sm text-gray-500">No logs yet</p>
+              ) : (
+                <ul className="text-sm list-disc list-inside space-y-1">
+                  {logs.map((l, i) => (
+                    <li key={i}>
+                      {l.phone}: {l.status}
+                      {l.error && ` - ${l.error}`}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
     </div>
   )

--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -47,28 +47,34 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
       >
         +
       </button>
-      <ul className="space-y-2">
+      <ul className="space-y-3">
         {campaigns.map(c => (
           <li
             key={c.id}
-            className="flex items-center justify-between border p-2 rounded"
+            className="flex items-center justify-between bg-white p-4 rounded shadow border"
           >
-            <span>{c.message_text.slice(0, 40)}...</span>
-            {c.status === 'running' ? (
-              <button
-                className="text-sm underline text-blue-600"
-                onClick={() => monitor(c.id)}
-              >
-                Monitor
-              </button>
-            ) : (
-              <button
-                className="text-sm underline text-green-700"
-                onClick={() => startCampaign(c.id)}
-              >
-                Run
-              </button>
-            )}
+            <div>
+              <p className="font-medium">Campaign #{c.id}</p>
+              <p className="text-sm text-gray-600">{c.message_text.slice(0, 60)}...</p>
+            </div>
+            <div className="flex items-center gap-4">
+              <span className={`text-xs px-2 py-1 rounded ${c.status === 'running' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'}`}>{c.status}</span>
+              {c.status === 'running' ? (
+                <button
+                  className="text-sm underline text-blue-600"
+                  onClick={() => monitor(c.id)}
+                >
+                  Monitor
+                </button>
+              ) : (
+                <button
+                  className="text-sm underline text-green-700"
+                  onClick={() => startCampaign(c.id)}
+                >
+                  Run
+                </button>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -94,10 +94,10 @@ export default function MainPage({ onLogout, accountId, sessionId, onSelectSessi
       <main className="flex-1 p-4 overflow-auto">
         <Routes>
           <Route path="/" element={<Navigate to="/editor" replace />} />
-          <Route path="/campaigns" element={<Campaigns accountId={accountId} />} />
+          <Route path="/campaigns" element={<Campaigns accountId={accountId} onSelectCampaign={setCampaignId} sessionId={sessionId} />} />
           <Route path="/editor" element={<CampaignEditor accountId={accountId} sessionId={sessionId} onSelectCampaign={setCampaignId} />} />
           <Route path="/analytics" element={<AnalyticsDashboard accountId={accountId} sessionId={sessionId} />} />
-          <Route path="/monitor" element={<CampaignMonitor campaignId={campaignId} />} />
+          <Route path="/monitor" element={<CampaignMonitor accountId={accountId} campaignId={campaignId} onSelectCampaign={setCampaignId} />} />
           <Route path="/connect" element={<ConnectTelegram accountId={accountId} sessionId={sessionId} onSelectSession={onSelectSession} />} />
           <Route path="/categories" element={<CategoryManager />} />
         </Routes>

--- a/tests/test_python_execute_campaign.py
+++ b/tests/test_python_execute_campaign.py
@@ -1,0 +1,15 @@
+import os
+import requests
+
+API = os.environ.get('PYTHON_API_BASE', 'https://retargetting-slave-api-production.up.railway.app')
+
+if __name__ == '__main__':
+    payload = {
+        'session': 'invalid',
+        'message': 'hi',
+        'recipients': ['+10000000000'],
+        'account_id': 1,
+        'campaign_id': 999
+    }
+    r = requests.post(f"{API}/execute_campaign", json=payload, timeout=10)
+    print('execute_campaign', r.status_code, r.text[:200])

--- a/tests/test_worker_campaigns.py
+++ b/tests/test_worker_campaigns.py
@@ -1,10 +1,34 @@
-import os, requests
+import os
+import time
+import requests
 
-API=os.environ.get('WORKER_BASE','https://retargetting-worker.elmtalabx.workers.dev')
+API = os.environ.get('WORKER_BASE', 'https://retargetting-worker.elmtalabx.workers.dev')
 
-
-if __name__=='__main__':
-    r=requests.post(f"{API}/campaigns", json={'name':'t'}, timeout=10)
+if __name__ == '__main__':
+    # create a new campaign using seeded account and session
+    payload = {
+        'account_id': 1,
+        'telegram_session_id': 1,
+        'message_text': 'test message'
+    }
+    r = requests.post(f"{API}/campaigns", json=payload, timeout=10)
     print('create campaign', r.status_code, r.text[:200])
-    r=requests.post(f"{API}/campaigns/1/start", timeout=10)
-    print('start campaign', r.status_code, r.text[:200])
+    cid = None
+    try:
+        data = r.json()
+        cid = data.get('id')
+    except Exception as e:
+        print('json error', e)
+
+    # verify campaign listed in GET /campaigns
+    if cid:
+        r = requests.get(f"{API}/campaigns?account_id=1", timeout=10)
+        print('list campaigns', r.status_code, r.text[:200])
+
+    # start the campaign
+    if cid:
+        r = requests.post(f"{API}/campaigns/{cid}/start", timeout=10)
+        print('start campaign', r.status_code, r.text[:200])
+        time.sleep(1)
+        r = requests.get(f"{API}/campaigns/{cid}/logs", timeout=10)
+        print('campaign logs', r.status_code, r.text[:200])


### PR DESCRIPTION
## Summary
- show running campaigns list in monitor page
- display campaign details when selected
- style campaigns list with more info
- add integration tests for creating and starting campaigns

## Testing
- `bash tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867877b45b8832f8bee04c8f8348b84