### PR TITLE
Interactive campaign stop/resume

### DIFF
--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -24,17 +24,21 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
   }, [accountId])
 
   const startCampaign = id => {
+    console.log('start/resume campaign', id)
     fetch(`${API_BASE}/campaigns/${id}/start`, { method: 'POST' })
       .then(() => {
         fetchCampaigns()
         onSelectCampaign && onSelectCampaign(id)
+        console.log('campaign started/resumed', id)
       })
       .catch(err => console.error('start campaign', err))
   }
 
   const stopCampaign = id => {
+    console.log('stop campaign', id)
     fetch(`${API_BASE}/campaigns/${id}/stop`, { method: 'POST' })
       .then(() => fetchCampaigns())
+      .then(() => console.log('campaign stopped', id))
       .catch(err => console.error('stop campaign', err))
   }
 
@@ -87,7 +91,7 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
                   className="text-sm underline text-green-700"
                   onClick={() => startCampaign(c.id)}
                 >
-                  Run
+                  {c.status === 'stopped' ? 'Resume' : 'Run'}
                 </button>
               )}
             </div>

--- a/python_api/app.py
+++ b/python_api/app.py
@@ -71,12 +71,16 @@ def execute_campaign():
     campaign_id = payload.get('campaign_id')
     account_id = payload.get('account_id')
     logger.info('execute_campaign payload %s', payload)
+    print('== Python API executing campaign', campaign_id, '==')
+    print('session snippet', session_str[:10] if session_str else None)
+    print('recipients count', len(recipients))
 
     if not session_str or not message or not recipients:
         return jsonify({'error': 'missing parameters'}), 400
 
     CAMPAIGN_LOGS[campaign_id] = []
     STOP_FLAGS[campaign_id] = False
+    print('STOP_FLAGS set to False for', campaign_id)
 
     async def _send():
         client = get_telegram_client(session_str)
@@ -85,17 +89,20 @@ def execute_campaign():
         for phone in recipients:
             if STOP_FLAGS.get(campaign_id):
                 logger.info('Campaign %s stop requested', campaign_id)
+                print('Stop flag detected for', campaign_id)
                 CAMPAIGN_LOGS[campaign_id].append({'status': 'stopped'})
                 break
             try:
                 await client.send_message(phone, message)
                 logger.info('sent to %s', phone)
+                print('message sent to', phone)
                 entry = {'phone': phone, 'status': 'sent'}
                 results.append(entry)
                 CAMPAIGN_LOGS[campaign_id].append(entry)
                 await asyncio.sleep(1)
             except Exception as e:
                 logger.error('send error %s %s', phone, e)
+                print('send error', phone, e)
                 entry = {'phone': phone, 'status': 'failed', 'error': str(e)}
                 results.append(entry)
                 CAMPAIGN_LOGS[campaign_id].append(entry)
@@ -106,9 +113,11 @@ def execute_campaign():
         results = asyncio.run(_send())
     except Exception as e:
         logger.error('execute_campaign error %s', e)
+        print('execute_campaign failed', e)
         return jsonify({'error': str(e)}), 500
 
     logger.info('campaign %s completed with %d results', campaign_id, len(results))
+    print('campaign', campaign_id, 'completed, results', len(results))
     return jsonify({'status': 'completed', 'results': results})
 
 
@@ -116,7 +125,9 @@ def execute_campaign():
 def stop_campaign(cid: int):
     """Request stopping an active campaign."""
     logger.info('stop_campaign %s', cid)
+    print('== Python API stop campaign', cid, '==')
     STOP_FLAGS[cid] = True
+    print('STOP_FLAGS set to True for', cid)
     CAMPAIGN_LOGS.setdefault(cid, []).append({'status': 'stop_requested'})
     return jsonify({'status': 'stopping'})
 


### PR DESCRIPTION
## Summary
- add a `Resume` label when a stopped campaign is restarted
- log start/resume and stop actions from the React UI
- emit extra console output in the worker when starting/stopping campaigns
- increase logging around campaign execution in the Python API

## Testing
- `bash tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868cd13233c832fa6c4ccf9efdabc31