### PR TITLE
Improve interactive stop/resume

### DIFF
--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import CampaignForm from './CampaignForm'
 
-const API_BASE =
+const API_BASE = (
   import.meta.env.VITE_API_BASE ||
   'https://retargetting-worker.elmtalabx.workers.dev'
+).replace(/\/$/, '')
 
 export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
   const [campaigns, setCampaigns] = useState([])
@@ -24,17 +25,35 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
   }, [accountId])
 
   const startCampaign = id => {
+    console.log('start/resume campaign', id)
     fetch(`${API_BASE}/campaigns/${id}/start`, { method: 'POST' })
+      .then(r => {
+        if (!r.ok) {
+          console.error('start campaign failed', r.status)
+          throw new Error('start failed')
+        }
+        return r
+      })
       .then(() => {
         fetchCampaigns()
         onSelectCampaign && onSelectCampaign(id)
+        console.log('campaign started/resumed', id)
       })
       .catch(err => console.error('start campaign', err))
   }
 
   const stopCampaign = id => {
+    console.log('stop campaign', id)
     fetch(`${API_BASE}/campaigns/${id}/stop`, { method: 'POST' })
+      .then(r => {
+        if (!r.ok) {
+          console.error('stop campaign failed', r.status)
+          throw new Error('stop failed')
+        }
+        return r
+      })
       .then(() => fetchCampaigns())
+      .then(() => console.log('campaign stopped', id))
       .catch(err => console.error('stop campaign', err))
   }
 
@@ -69,13 +88,13 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
 
                 <>
                   <button
-                    className="text-sm underline text-blue-600"
+                    className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
                     onClick={() => monitor(c.id)}
                   >
                     Monitor
                   </button>
                   <button
-                    className="text-sm underline text-red-600 ml-2"
+                    className="ml-2 px-2 py-1 text-sm bg-red-600 text-white rounded"
                     onClick={() => stopCampaign(c.id)}
                   >
                     Stop
@@ -84,10 +103,10 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
 
               ) : (
                 <button
-                  className="text-sm underline text-green-700"
+                  className="px-2 py-1 text-sm bg-green-600 text-white rounded"
                   onClick={() => startCampaign(c.id)}
                 >
-                  Run
+                  {c.status === 'stopped' ? 'Resume' : 'Run'}
                 </button>
               )}
             </div>

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -363,6 +363,7 @@ router.get('/campaigns', async (request: Request, env: Env) => {
 router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
   const id = Number(params?.id || 0)
   console.log('POST /campaigns/:id/start', id)
+  console.log('Fetching campaign details for', id)
   if (!id) return jsonResponse({ error: 'invalid id' }, 400)
 
   const row = await env.DB.prepare(
@@ -378,6 +379,7 @@ router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
   ).bind(row.account_id).all()
   const phoneRows = Array.isArray(phonesRes) ? phonesRes : phonesRes.results || []
   const recipients = phoneRows.map((r: any) => r.user_phone)
+  console.log('recipients count', recipients.length)
 
   let resp: Response
   try {
@@ -392,6 +394,7 @@ router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
         campaign_id: row.id,
       })
     })
+    console.log('execute_campaign response status', resp.status)
   } catch (err) {
     console.error('fetch execute_campaign error', err)
     return jsonResponse({ error: 'api request failed' }, 500)
@@ -405,6 +408,7 @@ router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
   await env.DB.prepare('UPDATE campaigns SET status=?1 WHERE id=?2')
     .bind('running', id)
     .run()
+  console.log('campaign', id, 'status set to running')
 
   return jsonResponse({ status: 'started', result: data })
 })
@@ -413,6 +417,7 @@ router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
 router.post('/campaigns/:id/stop', async ({ params }, env: Env) => {
   const id = Number(params?.id || 0)
   console.log('POST /campaigns/:id/stop', id)
+  console.log('Sending stop request to Python API for', id)
   if (!id) return jsonResponse({ error: 'invalid id' }, 400)
 
   let resp: Response
@@ -420,12 +425,14 @@ router.post('/campaigns/:id/stop', async ({ params }, env: Env) => {
     resp = await fetch(`${env.PYTHON_API_URL}/stop_campaign/${id}`, {
       method: 'POST',
     })
+    console.log('stop_campaign response status', resp.status)
   } catch (err) {
     console.error('fetch stop_campaign error', err)
     return jsonResponse({ error: 'api request failed' }, 500)
   }
 
   const data = await resp.json().catch(() => ({}))
+  console.log('stop_campaign response data', data)
   if (!resp.ok) {
     return jsonResponse({ error: 'python error', details: data }, resp.status)
   }
@@ -433,6 +440,7 @@ router.post('/campaigns/:id/stop', async ({ params }, env: Env) => {
   await env.DB.prepare('UPDATE campaigns SET status=?1 WHERE id=?2')
     .bind('stopped', id)
     .run()
+  console.log('campaign', id, 'status set to stopped')
 
   return jsonResponse({ status: 'stopped', result: data })
 })


### PR DESCRIPTION
## Summary
- sanitize API base URL in Campaigns component
- handle error codes when starting or stopping campaigns
- restyle campaign action buttons for clarity
- log Python API STOP_FLAGS when stop is requested
- print stop response data in the worker

## Testing
- `bash tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868cd13233c832fa6c4ccf9efdabc31