### PR TITLE
Fix monitoring stats and add recipient limit

### DIFF
--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -1,71 +1,84 @@
-import React, { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import CampaignForm from './CampaignForm'
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import CampaignForm from "./CampaignForm";
 
 const API_BASE = (
   import.meta.env.VITE_API_BASE ||
-  'https://retargetting-worker.elmtalabx.workers.dev'
-).replace(/\/$/, '')
+  "https://retargetting-worker.elmtalabx.workers.dev"
+).replace(/\/$/, "");
 
 export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
-  const [campaigns, setCampaigns] = useState([])
-  const [showForm, setShowForm] = useState(false)
-  const navigate = useNavigate()
+  const [campaigns, setCampaigns] = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const navigate = useNavigate();
 
   const fetchCampaigns = () => {
-    if (!accountId) return
+    if (!accountId) return;
     fetch(`${API_BASE}/campaigns?account_id=${accountId}`)
-      .then(r => r.json())
-      .then(d => setCampaigns(d.campaigns || []))
-      .catch(e => console.error('fetch campaigns', e))
-  }
+      .then((r) => r.json())
+      .then((d) => setCampaigns(d.campaigns || []))
+      .catch((e) => console.error("fetch campaigns", e));
+  };
 
   useEffect(() => {
-    fetchCampaigns()
-  }, [accountId])
+    fetchCampaigns();
+  }, [accountId]);
 
-  const startCampaign = id => {
-    console.log('start/resume campaign', id)
-    fetch(`${API_BASE}/campaigns/${id}/start`, { method: 'POST' })
-      .then(async r => {
+  const startCampaign = (id) => {
+    console.log("start/resume campaign", id);
+    const limitStr = prompt(
+      "How many users should this campaign message? Leave blank for all",
+    );
+    const limit = limitStr ? parseInt(limitStr, 10) : null;
+    const options = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    };
+    if (limit) options.body = JSON.stringify({ limit });
+    fetch(`${API_BASE}/campaigns/${id}/start`, options)
+      .then(async (r) => {
         if (!r.ok) {
-          console.error('start campaign failed', r.status)
-          const errorData = await r.json().catch(() => ({}))
-          console.error('Error details:', errorData)
-          throw new Error(errorData.error || errorData.message || `start failed (${r.status})`)
+          console.error("start campaign failed", r.status);
+          const errorData = await r.json().catch(() => ({}));
+          console.error("Error details:", errorData);
+          throw new Error(
+            errorData.error ||
+              errorData.message ||
+              `start failed (${r.status})`,
+          );
         }
-        return r
+        return r;
       })
       .then(() => {
-        fetchCampaigns()
-        onSelectCampaign && onSelectCampaign(id)
-        console.log('campaign started/resumed', id)
+        fetchCampaigns();
+        onSelectCampaign && onSelectCampaign(id);
+        console.log("campaign started/resumed", id);
       })
-      .catch(err => {
-        console.error('start campaign Error:', err.message)
-        alert(`Failed to start campaign: ${err.message}`)
-      })
-  }
+      .catch((err) => {
+        console.error("start campaign Error:", err.message);
+        alert(`Failed to start campaign: ${err.message}`);
+      });
+  };
 
-  const stopCampaign = id => {
-    console.log('stop campaign', id)
-    fetch(`${API_BASE}/campaigns/${id}/stop`, { method: 'POST' })
-      .then(r => {
+  const stopCampaign = (id) => {
+    console.log("stop campaign", id);
+    fetch(`${API_BASE}/campaigns/${id}/stop`, { method: "POST" })
+      .then((r) => {
         if (!r.ok) {
-          console.error('stop campaign failed', r.status)
-          throw new Error('stop failed')
+          console.error("stop campaign failed", r.status);
+          throw new Error("stop failed");
         }
-        return r
+        return r;
       })
       .then(() => fetchCampaigns())
-      .then(() => console.log('campaign stopped', id))
-      .catch(err => console.error('stop campaign', err))
-  }
+      .then(() => console.log("campaign stopped", id))
+      .catch((err) => console.error("stop campaign", err));
+  };
 
-  const monitor = id => {
-    onSelectCampaign && onSelectCampaign(id)
-    navigate('/monitor')
-  }
+  const monitor = (id) => {
+    onSelectCampaign && onSelectCampaign(id);
+    navigate("/monitor");
+  };
 
   return (
     <div className="p-6 relative">
@@ -78,19 +91,24 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
         +
       </button>
       <ul className="space-y-3">
-        {campaigns.map(c => (
+        {campaigns.map((c) => (
           <li
             key={c.id}
             className="flex items-center justify-between bg-white p-4 rounded shadow border"
           >
             <div>
               <p className="font-medium">Campaign #{c.id}</p>
-              <p className="text-sm text-gray-600">{c.message_text.slice(0, 60)}...</p>
+              <p className="text-sm text-gray-600">
+                {c.message_text.slice(0, 60)}...
+              </p>
             </div>
             <div className="flex items-center gap-4">
-              <span className={`text-xs px-2 py-1 rounded ${c.status === 'running' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'}`}>{c.status}</span>
-              {c.status === 'running' ? (
-
+              <span
+                className={`text-xs px-2 py-1 rounded ${c.status === "running" ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-700"}`}
+              >
+                {c.status}
+              </span>
+              {c.status === "running" ? (
                 <>
                   <button
                     className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
@@ -105,13 +123,12 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
                     Stop
                   </button>
                 </>
-
               ) : (
                 <button
                   className="px-2 py-1 text-sm bg-green-600 text-white rounded"
                   onClick={() => startCampaign(c.id)}
                 >
-                  {c.status === 'stopped' ? 'Resume' : 'Run'}
+                  {c.status === "stopped" ? "Resume" : "Run"}
                 </button>
               )}
             </div>
@@ -123,12 +140,12 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
           accountId={accountId}
           sessionId={sessionId}
           onSaved={() => {
-            setShowForm(false)
-            fetchCampaigns()
+            setShowForm(false);
+            fetchCampaigns();
           }}
           onClose={() => setShowForm(false)}
         />
       )}
     </div>
-  )
+  );
 }

--- a/python_api/main.py
+++ b/python_api/main.py
@@ -116,12 +116,14 @@ def execute_campaign():
     message = payload.get('message')
     account_id = payload.get('account_id')
     campaign_id = payload.get('campaign_id')
+    limit = payload.get('limit')
 
     print(f"[DEBUG] Parsed parameters:")
     print(f"  - session_str: {session_str[:50] + '...' if session_str else 'None'}")
     print(f"  - message: {message[:100] + '...' if message else 'None'}")
     print(f"  - account_id: {account_id}")
     print(f"  - campaign_id: {campaign_id}")
+    print(f"  - limit: {limit}")
 
     if not session_str or not message:
         print("[ERROR] Missing required parameters")
@@ -142,7 +144,7 @@ def execute_campaign():
     CAMPAIGN_STATUS[campaign_id] = {
         'status': 'running',
         'started_at': datetime.now().isoformat(),
-        'total_recipients': 0,  # Will be updated as we find dialogs
+        'total_recipients': int(limit) if isinstance(limit, (int, float, str)) and str(limit).isdigit() else 0,
         'sent_count': 0,
         'failed_count': 0,
         'current_recipient': None
@@ -179,13 +181,12 @@ def execute_campaign():
             return []
         
         results = []
-        total_dialogs = 0
         processed_dialogs = 0
         stopped = False
-        
-        print(f"[DEBUG] Starting to iterate through dialogs for campaign {campaign_id}")
-        
-        # Iterate through all dialogs (chats) that the user has
+
+        print(f"[DEBUG] Collecting recipients for campaign {campaign_id}")
+
+        recipients = []
         async for dialog in client.iter_dialogs():
             if STOP_FLAGS.get(campaign_id):
                 log_campaign_event(campaign_id, 'stop_requested', {})
@@ -194,57 +195,66 @@ def execute_campaign():
                 CAMPAIGN_STATUS[campaign_id]['completed_at'] = datetime.now().isoformat()
                 break
             try:
-                # Skip non-user dialogs (groups, channels, etc.)
                 if not dialog.is_user:
-                    print(f"[DEBUG] Skipping non-user dialog: {dialog.name}")
                     continue
-                
+
                 user = dialog.entity
-                
-                # Skip bots
                 if user.bot:
-                    print(f"[DEBUG] Skipping bot: {user.username or user.id}")
                     continue
-                
-                total_dialogs += 1
-                processed_dialogs += 1
-                
-                CAMPAIGN_STATUS[campaign_id]['current_recipient'] = f"{user.username or user.id}"
-                CAMPAIGN_STATUS[campaign_id]['total_recipients'] = total_dialogs
-                CAMPAIGN_STATUS[campaign_id]['progress'] = f"{processed_dialogs} dialogs processed"
-                
-                log_campaign_event(campaign_id, 'sending_message', {
-                    'recipient': f"{user.username or user.id}",
-                    'progress': f"{processed_dialogs} dialogs processed",
-                    'message_preview': message[:50] + '...' if len(message) > 50 else message
-                })
-                
-                print(f"[DEBUG] Sending message to dialog {processed_dialogs}: {user.username or user.id}")
-                
-                # Get user info for logging
-                user_info = f"{getattr(user, 'first_name', '')} {getattr(user, 'last_name', '')}"
-                log_campaign_event(campaign_id, 'recipient_info', {
-                    'recipient': f"{user.username or user.id}",
-                    'name': user_info.strip() or 'Unknown'
-                })
-                
-                # Send the message to this user
+
+                recipients.append(user)
+                if limit and str(limit).isdigit() and len(recipients) >= int(limit):
+                    break
+            except Exception as e:
+                print(f"[ERROR] Error while collecting recipients: {e}")
+
+        total_dialogs = len(recipients)
+        CAMPAIGN_STATUS[campaign_id]['total_recipients'] = total_dialogs
+
+        for user in recipients:
+            if STOP_FLAGS.get(campaign_id):
+                log_campaign_event(campaign_id, 'stop_requested', {})
+                stopped = True
+                CAMPAIGN_STATUS[campaign_id]['status'] = 'stopped'
+                CAMPAIGN_STATUS[campaign_id]['completed_at'] = datetime.now().isoformat()
+                break
+
+            processed_dialogs += 1
+
+            CAMPAIGN_STATUS[campaign_id]['current_recipient'] = f"{user.username or user.id}"
+            CAMPAIGN_STATUS[campaign_id]['progress'] = f"{processed_dialogs} of {len(recipients)}"
+
+            log_campaign_event(campaign_id, 'sending_message', {
+                'recipient': f"{user.username or user.id}",
+                'progress': f"{processed_dialogs} of {len(recipients)}",
+                'message_preview': message[:50] + '...' if len(message) > 50 else message
+            })
+
+            print(f"[DEBUG] Sending message to recipient {processed_dialogs}: {user.username or user.id}")
+
+            user_info = f"{getattr(user, 'first_name', '')} {getattr(user, 'last_name', '')}"
+            log_campaign_event(campaign_id, 'recipient_info', {
+                'recipient': f"{user.username or user.id}",
+                'name': user_info.strip() or 'Unknown'
+            })
+
+            try:
                 await client.send_message(user, message)
-                
+
                 CAMPAIGN_STATUS[campaign_id]['sent_count'] += 1
                 log_campaign_event(campaign_id, 'message_sent', {
                     'recipient': f"{user.username or user.id}",
                     'success': True
                 })
-                
+
                 results.append({
                     'recipient': f"{user.username or user.id}",
-                    'status': 'sent', 
+                    'status': 'sent',
                     'timestamp': datetime.now().isoformat()
                 })
-                
+
                 print(f"[DEBUG] Successfully sent message to {user.username or user.id}")
-                
+
                 # Rate limiting - delay between messages
                 await asyncio.sleep(1)
                 
@@ -506,13 +516,14 @@ def get_campaign_logs(campaign_id):
     # Convert logs to the format expected by the frontend
     formatted_logs = []
     for log in logs:
-        if log['type'] in ['message_sent', 'message_failed', 'message_sent_after_flood_wait', 'message_failed_after_flood_wait']:
-            formatted_logs.append({
-                'phone': log['details'].get('recipient', 'Unknown'),  # Now contains username/id
-                'status': 'sent' if 'sent' in log['type'] else 'failed',
-                'error': log['details'].get('error'),
-                'timestamp': log['timestamp']
-            })
+        status_label = 'sent' if 'message_sent' in log['type'] else (
+            'failed' if 'failed' in log['type'] else log['type'])
+        formatted_logs.append({
+            'phone': log['details'].get('recipient', ''),
+            'status': status_label,
+            'error': log['details'].get('error'),
+            'timestamp': log['timestamp']
+        })
     
     return jsonify({
         'logs': formatted_logs,
@@ -536,6 +547,11 @@ def get_campaign_status(campaign_id):
         progress_percent = ((sent_count + failed_count) / total_recipients) * 100
     else:
         progress_percent = 0
+
+    if sent_count + failed_count > 0:
+        success_rate = (sent_count / (sent_count + failed_count)) * 100
+    else:
+        success_rate = 0
     
     # Get recent activity
     recent_logs = logs[-10:] if logs else []
@@ -547,6 +563,7 @@ def get_campaign_status(campaign_id):
         'total_recipients': total_recipients,
         'sent_count': sent_count,
         'failed_count': failed_count,
+        'success_rate': f"{success_rate:.1f}%",
         'current_recipient': status.get('current_recipient'),
         'started_at': status.get('started_at'),
         'completed_at': status.get('completed_at'),

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,17 +1,17 @@
-import { Router } from 'itty-router'
+import { Router } from "itty-router";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type'
-}
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
 
 interface Env {
-  DB: D1Database
-  PYTHON_API_URL: string
+  DB: D1Database;
+  PYTHON_API_URL: string;
 }
 
-const router = Router()
+const router = Router();
 
 // Temporary type fixes for D1Database and ExecutionContext
 type D1Database = any;
@@ -103,281 +103,361 @@ CREATE TABLE IF NOT EXISTS pending_sessions (
 async function ensureSchema(db: D1Database) {
   try {
     await db.exec(INIT_SCHEMA);
-    const acctColsRes: any = await db.prepare('PRAGMA table_info(accounts)').all();
-    const acctCols = Array.isArray(acctColsRes) ? acctColsRes : acctColsRes.results || [];
+    const acctColsRes: any = await db
+      .prepare("PRAGMA table_info(accounts)")
+      .all();
+    const acctCols = Array.isArray(acctColsRes)
+      ? acctColsRes
+      : acctColsRes.results || [];
     const names = acctCols.map((c: any) => c.name);
-    if (!names.includes('password_hash')) {
-      console.log('adding password_hash column');
-      try { await db.exec('ALTER TABLE accounts ADD COLUMN password_hash TEXT'); } catch (e) { console.log('alter accounts error', e); }
+    if (!names.includes("password_hash")) {
+      console.log("adding password_hash column");
+      try {
+        await db.exec("ALTER TABLE accounts ADD COLUMN password_hash TEXT");
+      } catch (e) {
+        console.log("alter accounts error", e);
+      }
     }
   } catch (err) {
-    console.error('schema init error', err);
+    console.error("schema init error", err);
   }
 }
 
 async function hashPassword(pw: string): Promise<string> {
   const enc = new TextEncoder();
-  const buf = await crypto.subtle.digest('SHA-256', enc.encode(pw));
+  const buf = await crypto.subtle.digest("SHA-256", enc.encode(pw));
   return Array.from(new Uint8Array(buf))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 // Helper to return JSON with CORS headers
 function jsonResponse(obj: any, status = 200) {
   return new Response(JSON.stringify(obj), {
     status,
-    headers: { 'Content-Type': 'application/json', ...corsHeaders }
-  })
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
 }
 
 // Sign up new account
-router.post('/auth/signup', async (request: Request, env: Env) => {
-  const { email, password } = await request.json() as any
-  console.log('POST /auth/signup', email)
+router.post("/auth/signup", async (request: Request, env: Env) => {
+  const { email, password } = (await request.json()) as any;
+  console.log("POST /auth/signup", email);
   if (!email || !password) {
-    return jsonResponse({ error: 'missing parameters' }, 400)
+    return jsonResponse({ error: "missing parameters" }, 400);
   }
-  const hash = await hashPassword(password)
+  const hash = await hashPassword(password);
   try {
-    const colRes: any = await env.DB.prepare('PRAGMA table_info(accounts)').all()
-    const cols = Array.isArray(colRes) ? colRes : colRes.results || []
-    const names = cols.map((c: any) => c.name)
-    const fields = ['email', 'plan_type']
-    const placeholders = ['?1', '?2']
-    const values: any[] = [email, 'basic']
-    let idx = 3
-    if (names.includes('password_hash')) {
-      fields.push('password_hash')
-      placeholders.push('?' + idx)
-      values.push(hash)
-      idx++
+    const colRes: any = await env.DB.prepare(
+      "PRAGMA table_info(accounts)",
+    ).all();
+    const cols = Array.isArray(colRes) ? colRes : colRes.results || [];
+    const names = cols.map((c: any) => c.name);
+    const fields = ["email", "plan_type"];
+    const placeholders = ["?1", "?2"];
+    const values: any[] = [email, "basic"];
+    let idx = 3;
+    if (names.includes("password_hash")) {
+      fields.push("password_hash");
+      placeholders.push("?" + idx);
+      values.push(hash);
+      idx++;
     }
-    const sql = `INSERT INTO accounts (${fields.join(', ')}) VALUES (${placeholders.join(', ')})`
-    console.log('signup query', sql)
-    const res = await env.DB.prepare(sql).bind(...values).run()
-    console.log('created account id', res.lastRowId)
-    return jsonResponse({ id: res.lastRowId })
+    const sql = `INSERT INTO accounts (${fields.join(", ")}) VALUES (${placeholders.join(", ")})`;
+    console.log("signup query", sql);
+    const res = await env.DB.prepare(sql)
+      .bind(...values)
+      .run();
+    console.log("created account id", res.lastRowId);
+    return jsonResponse({ id: res.lastRowId });
   } catch (err: any) {
-    console.error('/auth/signup error', err)
-    if ((err.message || '').includes('UNIQUE')) {
-      return jsonResponse({ error: 'account exists' }, 409)
+    console.error("/auth/signup error", err);
+    if ((err.message || "").includes("UNIQUE")) {
+      return jsonResponse({ error: "account exists" }, 409);
     }
-    return jsonResponse({ error: 'db error' }, 500)
+    return jsonResponse({ error: "db error" }, 500);
   }
-})
+});
 
 // Authentication - simple login
-router.post('/auth/login', async (request: Request, env: Env) => {
-  const { email, password } = await request.json() as any
-  console.log('POST /auth/login', email)
+router.post("/auth/login", async (request: Request, env: Env) => {
+  const { email, password } = (await request.json()) as any;
+  console.log("POST /auth/login", email);
   if (!email || !password) {
-    return jsonResponse({ error: 'missing parameters' }, 400)
+    return jsonResponse({ error: "missing parameters" }, 400);
   }
-  const hash = await hashPassword(password)
-  let row
+  const hash = await hashPassword(password);
+  let row;
   try {
-    row = await env.DB.prepare('SELECT id, password_hash FROM accounts WHERE email=?1')
+    row = await env.DB.prepare(
+      "SELECT id, password_hash FROM accounts WHERE email=?1",
+    )
       .bind(email)
-      .first()
+      .first();
   } catch (err) {
-    console.error('/auth/login query error', err)
-    return jsonResponse({ error: 'db error' }, 500)
+    console.error("/auth/login query error", err);
+    return jsonResponse({ error: "db error" }, 500);
   }
   if (row && row.password_hash && row.password_hash === hash) {
-    console.log('login success for account', row.id)
-    return jsonResponse({ id: row.id })
+    console.log("login success for account", row.id);
+    return jsonResponse({ id: row.id });
   }
-  console.log('login failed for', email)
-  return jsonResponse({ error: 'invalid credentials' }, 401)
-})
+  console.log("login failed for", email);
+  return jsonResponse({ error: "invalid credentials" }, 401);
+});
 
 // Begin Telegram session - send code
-router.post('/session/connect', async (request: Request, env: Env) => {
-  const { phone, account_id } = await request.json() as any
-  console.log('worker /session/connect phone', phone, 'account', account_id)
-  const accountId = Number(account_id || 0)
+router.post("/session/connect", async (request: Request, env: Env) => {
+  const { phone, account_id } = (await request.json()) as any;
+  console.log("worker /session/connect phone", phone, "account", account_id);
+  const accountId = Number(account_id || 0);
   if (!accountId) {
-    return new Response(JSON.stringify({ error: 'account_id required' }), { status: 400 })
+    return new Response(JSON.stringify({ error: "account_id required" }), {
+      status: 400,
+    });
   }
 
-  let resp
+  let resp;
   try {
     resp = await fetch(`${env.PYTHON_API_URL}/session/connect`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ phone })
-    })
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ phone }),
+    });
   } catch (err) {
-    console.error('worker connect fetch error', err)
-    return new Response(JSON.stringify({ error: 'Failed to contact API', details: err && ((err as any).stack || (err as any).message || err.toString()) }), { status: 500 })
+    console.error("worker connect fetch error", err);
+    return new Response(
+      JSON.stringify({
+        error: "Failed to contact API",
+        details:
+          err && ((err as any).stack || (err as any).message || err.toString()),
+      }),
+      { status: 500 },
+    );
   }
-  console.log('python api response status', resp.status)
-  let data
+  console.log("python api response status", resp.status);
+  let data;
   try {
-    data = await resp.json()
+    data = await resp.json();
   } catch (err) {
-    console.error('worker connect json error', err)
-    return new Response(JSON.stringify({ error: 'Bad response from API', details: err && ((err as any).stack || (err as any).message || err.toString()) }), { status: 500 })
+    console.error("worker connect json error", err);
+    return new Response(
+      JSON.stringify({
+        error: "Bad response from API",
+        details:
+          err && ((err as any).stack || (err as any).message || err.toString()),
+      }),
+      { status: 500 },
+    );
   }
-  console.log('python api response body', data)
+  console.log("python api response body", data);
   if (!resp.ok) {
-    console.error('worker /session/connect python api error', data)
-    return new Response(JSON.stringify({ error: 'Python API error', details: data }), { status: resp.status })
+    console.error("worker /session/connect python api error", data);
+    return new Response(
+      JSON.stringify({ error: "Python API error", details: data }),
+      { status: resp.status },
+    );
   }
   if (!(data && (data as any).session && (data as any).phone_code_hash)) {
-    console.error('worker /session/connect missing session or phone_code_hash', data)
-    return new Response(JSON.stringify({ error: 'Failed to send code', details: data }), { status: 500 })
+    console.error(
+      "worker /session/connect missing session or phone_code_hash",
+      data,
+    );
+    return new Response(
+      JSON.stringify({ error: "Failed to send code", details: data }),
+      { status: 500 },
+    );
   }
   try {
     await env.DB.prepare(
-      'INSERT OR REPLACE INTO pending_sessions (account_id, phone, session, phone_code_hash) VALUES (?1, ?2, ?3, ?4)'
+      "INSERT OR REPLACE INTO pending_sessions (account_id, phone, session, phone_code_hash) VALUES (?1, ?2, ?3, ?4)",
     )
-      .bind(accountId, phone, (data as any).session, (data as any).phone_code_hash)
-      .run()
+      .bind(
+        accountId,
+        phone,
+        (data as any).session,
+        (data as any).phone_code_hash,
+      )
+      .run();
   } catch (err) {
-    console.error('worker /session/connect DB error', err)
-    return new Response(JSON.stringify({ error: 'DB error', details: err && ((err as any).stack || (err as any).message || err.toString()) }), { status: 500 })
+    console.error("worker /session/connect DB error", err);
+    return new Response(
+      JSON.stringify({
+        error: "DB error",
+        details:
+          err && ((err as any).stack || (err as any).message || err.toString()),
+      }),
+      { status: 500 },
+    );
   }
-  return new Response(JSON.stringify({ status: 'code_sent' }), {
-    headers: { 'Content-Type': 'application/json' }
-  })
-})
+  return new Response(JSON.stringify({ status: "code_sent" }), {
+    headers: { "Content-Type": "application/json" },
+  });
+});
 
 // Verify telegram login code
-router.post('/session/verify', async (request: Request, env: Env) => {
-  const { phone, code, account_id } = await request.json() as any
-  console.log('worker /session/verify phone', phone, 'code', code, 'account', account_id)
-  const accountId = Number(account_id || 0)
+router.post("/session/verify", async (request: Request, env: Env) => {
+  const { phone, code, account_id } = (await request.json()) as any;
+  console.log(
+    "worker /session/verify phone",
+    phone,
+    "code",
+    code,
+    "account",
+    account_id,
+  );
+  const accountId = Number(account_id || 0);
   if (!accountId) {
-    return new Response('account_id required', { status: 400 })
+    return new Response("account_id required", { status: 400 });
   }
   const row = await env.DB.prepare(
-    'SELECT phone, session, phone_code_hash FROM pending_sessions WHERE account_id=?1'
+    "SELECT phone, session, phone_code_hash FROM pending_sessions WHERE account_id=?1",
   )
     .bind(accountId)
-    .first()
+    .first();
 
   if (!row) {
-    return new Response('No pending session', { status: 400 })
+    return new Response("No pending session", { status: 400 });
   }
 
-  let resp
+  let resp;
   try {
     resp = await fetch(`${env.PYTHON_API_URL}/session/verify`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         phone,
         code,
         session: row.session,
-        phone_code_hash: row.phone_code_hash
-      })
-    })
+        phone_code_hash: row.phone_code_hash,
+      }),
+    });
   } catch (err) {
-    console.error('worker verify fetch error', err)
-    return new Response('Failed to contact API', { status: 500 })
+    console.error("worker verify fetch error", err);
+    return new Response("Failed to contact API", { status: 500 });
   }
 
-  console.log('python api verify status', resp.status)
+  console.log("python api verify status", resp.status);
 
-
-  let data
+  let data;
   try {
-    data = await resp.json()
+    data = await resp.json();
   } catch (err) {
-    console.error('worker verify json error', err)
-    return new Response('Bad response from API', { status: 500 })
+    console.error("worker verify json error", err);
+    return new Response("Bad response from API", { status: 500 });
   }
 
-  console.log('python api verify body', data)
+  console.log("python api verify body", data);
   if (!resp.ok) {
-    return new Response(JSON.stringify(data), { status: resp.status })
+    return new Response(JSON.stringify(data), { status: resp.status });
   }
 
   const insertRes = await env.DB.prepare(
-    'INSERT INTO telegram_sessions (account_id, phone, encrypted_session_data) VALUES (?1, ?2, ?3)'
+    "INSERT INTO telegram_sessions (account_id, phone, encrypted_session_data) VALUES (?1, ?2, ?3)",
   )
     .bind(accountId, row.phone, (data as any).session)
-    .run()
-  const newSessionId = insertRes.lastRowId
-  console.log('stored session id', newSessionId)
+    .run();
+  const newSessionId = insertRes.lastRowId;
+  console.log("stored session id", newSessionId);
 
-  await env.DB.prepare('DELETE FROM pending_sessions WHERE account_id=?1')
+  await env.DB.prepare("DELETE FROM pending_sessions WHERE account_id=?1")
     .bind(accountId)
-    .run()
+    .run();
 
-  return new Response(JSON.stringify({ status: 'connected', session_id: newSessionId }), {
-    headers: { 'Content-Type': 'application/json' }
-  })
-})
+  return new Response(
+    JSON.stringify({ status: "connected", session_id: newSessionId }),
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+});
 
 // Check if a telegram session exists for the account
-router.get('/session/status', async (request: Request, env: Env) => {
-  const url = new URL(request.url)
-  const accountId = Number(url.searchParams.get('account_id') || 0)
-  console.log('GET /session/status account', accountId)
+router.get("/session/status", async (request: Request, env: Env) => {
+  const url = new URL(request.url);
+  const accountId = Number(url.searchParams.get("account_id") || 0);
+  console.log("GET /session/status account", accountId);
   if (!accountId) {
-    return new Response(JSON.stringify({ error: 'account_id required' }), { status: 400 })
+    return new Response(JSON.stringify({ error: "account_id required" }), {
+      status: 400,
+    });
   }
   const { results } = await env.DB.prepare(
-    'SELECT id, phone FROM telegram_sessions WHERE account_id=?1'
-  ).bind(accountId).all()
-  const sessions = Array.isArray(results) ? results : results.results || []
-  console.log('session list', sessions)
-  return new Response(JSON.stringify({ sessions }), { headers: { 'Content-Type': 'application/json' } })
-})
+    "SELECT id, phone FROM telegram_sessions WHERE account_id=?1",
+  )
+    .bind(accountId)
+    .all();
+  const sessions = Array.isArray(results) ? results : results.results || [];
+  console.log("session list", sessions);
+  return new Response(JSON.stringify({ sessions }), {
+    headers: { "Content-Type": "application/json" },
+  });
+});
 
 // Campaign creation placeholder
-router.post('/campaigns', async (request: Request, env: Env) => {
-  const { account_id, telegram_session_id, message_text } = await request.json() as any
-  console.log('POST /campaigns', { account_id, telegram_session_id })
-  const accountId = Number(account_id || 0)
+router.post("/campaigns", async (request: Request, env: Env) => {
+  const { account_id, telegram_session_id, message_text } =
+    (await request.json()) as any;
+  console.log("POST /campaigns", { account_id, telegram_session_id });
+  const accountId = Number(account_id || 0);
   if (!accountId || !telegram_session_id || !message_text) {
-    return jsonResponse({ error: 'missing parameters' }, 400)
+    return jsonResponse({ error: "missing parameters" }, 400);
   }
 
   const res = await env.DB.prepare(
-    'INSERT INTO campaigns (account_id, telegram_session_id, message_text, status) VALUES (?1, ?2, ?3, ?4)'
+    "INSERT INTO campaigns (account_id, telegram_session_id, message_text, status) VALUES (?1, ?2, ?3, ?4)",
   )
-    .bind(accountId, telegram_session_id, message_text, 'created')
-    .run()
+    .bind(accountId, telegram_session_id, message_text, "created")
+    .run();
 
-  return jsonResponse({ id: res.lastRowId })
-})
+  return jsonResponse({ id: res.lastRowId });
+});
 
 // List campaigns for an account
-router.get('/campaigns', async (request: Request, env: Env) => {
-  const url = new URL(request.url)
-  const accountId = Number(url.searchParams.get('account_id') || 0)
-  if (!accountId) return jsonResponse({ error: 'account_id required' }, 400)
+router.get("/campaigns", async (request: Request, env: Env) => {
+  const url = new URL(request.url);
+  const accountId = Number(url.searchParams.get("account_id") || 0);
+  if (!accountId) return jsonResponse({ error: "account_id required" }, 400);
 
   const { results } = await env.DB.prepare(
-    'SELECT id, message_text, status FROM campaigns WHERE account_id=?1 ORDER BY id DESC'
-  ).bind(accountId).all()
-  const rows = Array.isArray(results) ? results : results.results || []
-  return jsonResponse({ campaigns: rows })
-})
+    "SELECT id, message_text, status FROM campaigns WHERE account_id=?1 ORDER BY id DESC",
+  )
+    .bind(accountId)
+    .all();
+  const rows = Array.isArray(results) ? results : results.results || [];
+  return jsonResponse({ campaigns: rows });
+});
 
 // Start campaign - schedule job
-router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
-  const id = Number(params?.id || 0)
-  console.log('POST /campaigns/:id/start', id)
-  console.log('Fetching campaign details for', id)
-  if (!id) return jsonResponse({ error: 'invalid id' }, 400)
+router.post("/campaigns/:id/start", async ({ params, request }, env: Env) => {
+  const id = Number(params?.id || 0);
+  console.log("POST /campaigns/:id/start", id);
+  console.log("Fetching campaign details for", id);
+  if (!id) return jsonResponse({ error: "invalid id" }, 400);
 
   const row = await env.DB.prepare(
     `SELECT c.id, c.account_id, c.message_text, c.telegram_session_id, t.encrypted_session_data
      FROM campaigns c JOIN telegram_sessions t ON c.telegram_session_id=t.id
-     WHERE c.id=?1`
-  ).bind(id).first()
+     WHERE c.id=?1`,
+  )
+    .bind(id)
+    .first();
 
-  console.log('Campaign row:', row)
-  if (!row) return jsonResponse({ error: 'not found' }, 404)
+  console.log("Campaign row:", row);
+  if (!row) return jsonResponse({ error: "not found" }, 404);
 
   if (!row.encrypted_session_data) {
-    console.error('No session data found for campaign', id)
-    return jsonResponse({ error: 'no session data found' }, 400)
+    console.error("No session data found for campaign", id);
+    return jsonResponse({ error: "no session data found" }, 400);
+  }
+
+  let limit: number | undefined;
+  try {
+    const body = await request.json();
+    limit = Number(body?.limit);
+    if (!Number.isFinite(limit) || limit <= 0) limit = undefined;
+  } catch (err) {
+    limit = undefined;
   }
 
   // Log the request being sent to Python API
@@ -386,197 +466,234 @@ router.post('/campaigns/:id/start', async ({ params }, env: Env) => {
     message: row.message_text,
     account_id: row.account_id,
     campaign_id: row.id,
-  }
-  console.log('Sending to Python API:', {
+    ...(limit ? { limit } : {}),
+  };
+  console.log("Sending to Python API:", {
     ...requestBody,
-    session: row.encrypted_session_data ? row.encrypted_session_data.substring(0, 50) + '...' : 'null'
-  })
+    session: row.encrypted_session_data
+      ? row.encrypted_session_data.substring(0, 50) + "..."
+      : "null",
+  });
 
-  await env.DB.prepare('UPDATE campaigns SET status=?1 WHERE id=?2')
-    .bind('running', id)
-    .run()
-  console.log('campaign', id, 'status set to running')
+  await env.DB.prepare("UPDATE campaigns SET status=?1 WHERE id=?2")
+    .bind("running", id)
+    .run();
+  console.log("campaign", id, "status set to running");
 
-  let resp: Response
+  let resp: Response;
   try {
     resp = await fetch(`${env.PYTHON_API_URL}/execute_campaign`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(requestBody)
-    })
-    console.log('execute_campaign response status', resp.status)
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+    console.log("execute_campaign response status", resp.status);
   } catch (err) {
-    console.error('fetch execute_campaign error', err)
-    return jsonResponse({ error: 'api request failed', details: err && ((err as any).stack || (err as any).message || err.toString()) }, 500)
+    console.error("fetch execute_campaign error", err);
+    return jsonResponse(
+      {
+        error: "api request failed",
+        details:
+          err && ((err as any).stack || (err as any).message || err.toString()),
+      },
+      500,
+    );
   }
 
-  const data = await resp.json().catch(() => ({}))
-  console.log('execute_campaign response data:', data)
+  const data = await resp.json().catch(() => ({}));
+  console.log("execute_campaign response data:", data);
   if (!resp.ok) {
-    console.error('Python API returned error:', data)
-    return jsonResponse({ error: 'python error', details: data }, resp.status)
+    console.error("Python API returned error:", data);
+    return jsonResponse({ error: "python error", details: data }, resp.status);
   }
 
-  return jsonResponse({ status: 'started', result: data })
-})
+  return jsonResponse({ status: "started", result: data });
+});
 
 // Stop a running campaign (POST and GET, with and without trailing slash)
 const stopCampaignHandler = async ({ params }: { params: any }, env: Env) => {
-  const logs: string[] = []
-  const id = Number(params?.id || 0)
-  logs.push(`[STOP] Called for campaign id: ${id}`)
+  const logs: string[] = [];
+  const id = Number(params?.id || 0);
+  logs.push(`[STOP] Called for campaign id: ${id}`);
   if (!id) {
-    logs.push('[STOP] Invalid id')
-    return jsonResponse({ error: 'invalid id', logs }, 400)
+    logs.push("[STOP] Invalid id");
+    return jsonResponse({ error: "invalid id", logs }, 400);
   }
 
-  let resp: Response
+  let resp: Response;
   try {
-    logs.push(`[STOP] Sending request to Python API: ${env.PYTHON_API_URL}/stop_campaign/${id}`)
+    logs.push(
+      `[STOP] Sending request to Python API: ${env.PYTHON_API_URL}/stop_campaign/${id}`,
+    );
     resp = await fetch(`${env.PYTHON_API_URL}/stop_campaign/${id}`, {
-      method: 'POST',
-    })
-    logs.push(`[STOP] Python API response status: ${resp.status}`)
+      method: "POST",
+    });
+    logs.push(`[STOP] Python API response status: ${resp.status}`);
   } catch (err) {
-    logs.push(`[STOP] Fetch error: ${err && ((err as any).stack || (err as any).message || err.toString())}`)
-    return jsonResponse({ error: 'api request failed', logs }, 500)
+    logs.push(
+      `[STOP] Fetch error: ${err && ((err as any).stack || (err as any).message || err.toString())}`,
+    );
+    return jsonResponse({ error: "api request failed", logs }, 500);
   }
 
-  const data = await resp.json().catch(e => { logs.push(`[STOP] JSON parse error: ${e}`); return {} })
-  logs.push(`[STOP] Python API response data: ${JSON.stringify(data)}`)
+  const data = await resp.json().catch((e) => {
+    logs.push(`[STOP] JSON parse error: ${e}`);
+    return {};
+  });
+  logs.push(`[STOP] Python API response data: ${JSON.stringify(data)}`);
   if (!resp.ok) {
-    logs.push('[STOP] Python API returned error')
-    return jsonResponse({ error: 'python error', details: data, logs }, resp.status)
+    logs.push("[STOP] Python API returned error");
+    return jsonResponse(
+      { error: "python error", details: data, logs },
+      resp.status,
+    );
   }
 
   try {
-    await env.DB.prepare('UPDATE campaigns SET status=?1 WHERE id=?2')
-      .bind('stopped', id)
-      .run()
-    logs.push(`[STOP] Campaign ${id} status set to stopped in DB`)
+    await env.DB.prepare("UPDATE campaigns SET status=?1 WHERE id=?2")
+      .bind("stopped", id)
+      .run();
+    logs.push(`[STOP] Campaign ${id} status set to stopped in DB`);
   } catch (err) {
-    logs.push(`[STOP] DB update error: ${err && ((err as any).stack || (err as any).message || err.toString())}`)
-    return jsonResponse({ error: 'db error', logs }, 500)
+    logs.push(
+      `[STOP] DB update error: ${err && ((err as any).stack || (err as any).message || err.toString())}`,
+    );
+    return jsonResponse({ error: "db error", logs }, 500);
   }
 
-  logs.push(`[STOP] Success for campaign ${id}`)
-  return jsonResponse({ status: 'stopped', result: data, logs })
-}
-router.post('/campaigns/:id/stop', stopCampaignHandler)
-router.post('/campaigns/:id/stop/', stopCampaignHandler)
-router.get('/campaigns/:id/stop', stopCampaignHandler)
-router.get('/campaigns/:id/stop/', stopCampaignHandler)
+  logs.push(`[STOP] Success for campaign ${id}`);
+  return jsonResponse({ status: "stopped", result: data, logs });
+};
+router.post("/campaigns/:id/stop", stopCampaignHandler);
+router.post("/campaigns/:id/stop/", stopCampaignHandler);
+router.get("/campaigns/:id/stop", stopCampaignHandler);
+router.get("/campaigns/:id/stop/", stopCampaignHandler);
 
 // List categories
-router.get('/categories', async (request: Request, env: Env) => {
-  const accountId = 1
+router.get("/categories", async (request: Request, env: Env) => {
+  const accountId = 1;
 
-  console.log('GET /categories account', accountId)
+  console.log("GET /categories account", accountId);
   const { results } = await env.DB.prepare(
-    'SELECT id, name, keywords_json, description, sample_chats_json FROM categories WHERE account_id=?1'
+    "SELECT id, name, keywords_json, description, sample_chats_json FROM categories WHERE account_id=?1",
   )
     .bind(accountId)
-    .all()
-  console.log('categories results', results)
+    .all();
+  console.log("categories results", results);
 
   return new Response(JSON.stringify({ categories: results }), {
-    headers: { 'Content-Type': 'application/json' },
-  })
-})
+    headers: { "Content-Type": "application/json" },
+  });
+});
 
 // Create category
-router.post('/categories', async (request: Request, env: Env) => {
-
-  const { name, keywords, description, examples } = await request.json() as any
-  const accountId = 1
-  console.log('POST /categories', { name, keywords, description, examples })
+router.post("/categories", async (request: Request, env: Env) => {
+  const { name, keywords, description, examples } =
+    (await request.json()) as any;
+  const accountId = 1;
+  console.log("POST /categories", { name, keywords, description, examples });
 
   const res = await env.DB.prepare(
-    'INSERT INTO categories (account_id, name, keywords_json, description, sample_chats_json) VALUES (?1, ?2, ?3, ?4, ?5)'
+    "INSERT INTO categories (account_id, name, keywords_json, description, sample_chats_json) VALUES (?1, ?2, ?3, ?4, ?5)",
   )
-    .bind(accountId, name, JSON.stringify(keywords || []), description || '', JSON.stringify(examples || []))
+    .bind(
+      accountId,
+      name,
+      JSON.stringify(keywords || []),
+      description || "",
+      JSON.stringify(examples || []),
+    )
 
-    .run()
-  console.log('inserted category id', res.lastRowId)
+    .run();
+  console.log("inserted category id", res.lastRowId);
 
   return new Response(JSON.stringify({ id: res.lastRowId }), {
-    headers: { 'Content-Type': 'application/json' },
-  })
-})
+    headers: { "Content-Type": "application/json" },
+  });
+});
 
 // Analytics summary
-router.get('/analytics/summary', async (request: Request, env: Env) => {
-  const url = new URL(request.url)
-  const accountId = Number(url.searchParams.get('account_id') || 0)
-  const sessionId = Number(url.searchParams.get('session_id') || 0)
-  
-  console.log('GET /analytics/summary account', accountId, 'session', sessionId)
+router.get("/analytics/summary", async (request: Request, env: Env) => {
+  const url = new URL(request.url);
+  const accountId = Number(url.searchParams.get("account_id") || 0);
+  const sessionId = Number(url.searchParams.get("session_id") || 0);
+
+  console.log(
+    "GET /analytics/summary account",
+    accountId,
+    "session",
+    sessionId,
+  );
   try {
     const totalRow = await env.DB.prepare(
-      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
+      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1${sessionId ? " AND c.telegram_session_id=?2" : ""}`,
     )
       .bind(accountId, sessionId)
-      .first()
-    console.log('totalRow', totalRow)
+      .first();
+    console.log("totalRow", totalRow);
 
     const successRow = await env.DB.prepare(
-      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1 AND s.status='sent'${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
+      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1 AND s.status='sent'${sessionId ? " AND c.telegram_session_id=?2" : ""}`,
     )
       .bind(accountId, sessionId)
-      .first()
-    console.log('successRow', successRow)
+      .first();
+    console.log("successRow", successRow);
 
     const failRow = await env.DB.prepare(
-      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1 AND s.status!='sent'${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
+      `SELECT COUNT(*) as cnt FROM sent_logs s JOIN campaigns c ON s.campaign_id=c.id WHERE c.account_id=?1 AND s.status!='sent'${sessionId ? " AND c.telegram_session_id=?2" : ""}`,
     )
       .bind(accountId, sessionId)
-      .first()
-    console.log('failRow', failRow)
+      .first();
+    console.log("failRow", failRow);
 
     const revenueRow = await env.DB.prepare(
-      `SELECT SUM(revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
+      `SELECT SUM(revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1${sessionId ? " AND c.telegram_session_id=?2" : ""}`,
     )
       .bind(accountId, sessionId)
-      .first()
-    console.log('revenueRow', revenueRow)
+      .first();
+    console.log("revenueRow", revenueRow);
 
     const categoryRowsResult = await env.DB.prepare(
-      `SELECT category, COUNT(*) as count FROM customer_categories WHERE account_id=?1 GROUP BY category`
+      `SELECT category, COUNT(*) as count FROM customer_categories WHERE account_id=?1 GROUP BY category`,
     )
       .bind(accountId)
-      .all()
-    const categoryRows = Array.isArray(categoryRowsResult) ? categoryRowsResult : categoryRowsResult.results || []
-    console.log('categoryRows', categoryRows)
+      .all();
+    const categoryRows = Array.isArray(categoryRowsResult)
+      ? categoryRowsResult
+      : categoryRowsResult.results || [];
+    console.log("categoryRows", categoryRows);
 
     const campaignRowsResult = await env.DB.prepare(
-      `SELECT c.id, c.message_text, COALESCE(a.total_sent,0) as total_sent, c.telegram_session_id FROM campaigns c LEFT JOIN campaign_analytics a ON c.id=a.campaign_id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''}`
+      `SELECT c.id, c.message_text, COALESCE(a.total_sent,0) as total_sent, c.telegram_session_id FROM campaigns c LEFT JOIN campaign_analytics a ON c.id=a.campaign_id WHERE c.account_id=?1${sessionId ? " AND c.telegram_session_id=?2" : ""}`,
     )
       .bind(accountId, sessionId)
-      .all()
-    const campaignRows = Array.isArray(campaignRowsResult) ? campaignRowsResult : campaignRowsResult.results || []
-    console.log('campaignRows', campaignRows)
+      .all();
+    const campaignRows = Array.isArray(campaignRowsResult)
+      ? campaignRowsResult
+      : campaignRowsResult.results || [];
+    console.log("campaignRows", campaignRows);
 
-    let revenueDayRows = []
+    let revenueDayRows = [];
     try {
       revenueDayRows = await env.DB.prepare(
-        `SELECT strftime("%Y-%m-%d", tl.created_at) as day, SUM(tl.revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1${sessionId ? ' AND c.telegram_session_id=?2' : ''} GROUP BY day ORDER BY day`
+        `SELECT strftime("%Y-%m-%d", tl.created_at) as day, SUM(tl.revenue) as rev FROM trackable_links tl JOIN campaigns c ON c.id=tl.campaign_id WHERE c.account_id=?1${sessionId ? " AND c.telegram_session_id=?2" : ""} GROUP BY day ORDER BY day`,
       )
         .bind(accountId, sessionId)
-        .all()
-      if (!Array.isArray(revenueDayRows)) revenueDayRows = []
+        .all();
+      if (!Array.isArray(revenueDayRows)) revenueDayRows = [];
     } catch (e) {
-      console.error('revenueDayRows query failed', e)
-      revenueDayRows = []
+      console.error("revenueDayRows query failed", e);
+      revenueDayRows = [];
     }
-    console.log('revenueDayRows', revenueDayRows)
+    console.log("revenueDayRows", revenueDayRows);
 
     const metrics = {
       messages_sent: totalRow?.cnt || 0,
       successes: successRow?.cnt || 0,
       failures: failRow?.cnt || 0,
       revenue: revenueRow?.rev || 0,
-    }
-    console.log('metrics', metrics)
+    };
+    console.log("metrics", metrics);
 
     return new Response(
       JSON.stringify({
@@ -585,166 +702,204 @@ router.get('/analytics/summary', async (request: Request, env: Env) => {
         campaigns: campaignRows,
         revenueByDay: revenueDayRows,
       }),
-      { headers: { 'Content-Type': 'application/json' } }
-    )
+      { headers: { "Content-Type": "application/json" } },
+    );
   } catch (err) {
-    console.error('/analytics/summary error', err)
-    return new Response(JSON.stringify({ error: 'analytics failed' }), {
+    console.error("/analytics/summary error", err);
+    return new Response(JSON.stringify({ error: "analytics failed" }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+      headers: { "Content-Type": "application/json" },
+    });
   }
+});
 
-})
-
-router.get('/campaigns/:id/analytics', async ({ params }, env: Env) => {
+router.get("/campaigns/:id/analytics", async ({ params }, env: Env) => {
   const row = await env.DB.prepare(
-    'SELECT * FROM campaign_analytics WHERE campaign_id=?1'
+    "SELECT * FROM campaign_analytics WHERE campaign_id=?1",
   )
     .bind(params?.id)
-    .first()
+    .first();
   return new Response(JSON.stringify({ analytics: row }), {
-    headers: { 'Content-Type': 'application/json' },
-  })
-})
+    headers: { "Content-Type": "application/json" },
+  });
+});
 
 // Fetch logs for a campaign from the Python API (GET, with and without trailing slash)
 const campaignLogsHandler = async ({ params }: { params: any }, env: Env) => {
-  const logs: string[] = []
-  const id = Number(params?.id || 0)
-  logs.push(`[LOGS] Called for campaign id: ${id}`)
+  const logs: string[] = [];
+  const id = Number(params?.id || 0);
+  logs.push(`[LOGS] Called for campaign id: ${id}`);
   if (!id) {
-    logs.push('[LOGS] Invalid id')
-    return jsonResponse({ error: 'invalid id', logs }, 400)
+    logs.push("[LOGS] Invalid id");
+    return jsonResponse({ error: "invalid id", logs }, 400);
   }
-  let resp: Response
+  let resp: Response;
   try {
-    logs.push(`[LOGS] Fetching logs from Python API: ${env.PYTHON_API_URL}/campaign_logs/${id}`)
-    resp = await fetch(`${env.PYTHON_API_URL}/campaign_logs/${id}`)
-    logs.push(`[LOGS] Python API response status: ${resp.status}`)
+    logs.push(
+      `[LOGS] Fetching logs from Python API: ${env.PYTHON_API_URL}/campaign_logs/${id}`,
+    );
+    resp = await fetch(`${env.PYTHON_API_URL}/campaign_logs/${id}`);
+    logs.push(`[LOGS] Python API response status: ${resp.status}`);
   } catch (err) {
-    logs.push(`[LOGS] Fetch error: ${err && ((err as any).stack || (err as any).message || err.toString())}`)
-    return jsonResponse({ error: 'api request failed', logs }, 500)
+    logs.push(
+      `[LOGS] Fetch error: ${err && ((err as any).stack || (err as any).message || err.toString())}`,
+    );
+    return jsonResponse({ error: "api request failed", logs }, 500);
   }
-  const data = await resp.json().catch(e => { logs.push(`[LOGS] JSON parse error: ${e}`); return {} })
-  logs.push(`[LOGS] Python API response data: ${JSON.stringify(data)}`)
+  const data = await resp.json().catch((e) => {
+    logs.push(`[LOGS] JSON parse error: ${e}`);
+    return {};
+  });
+  logs.push(`[LOGS] Python API response data: ${JSON.stringify(data)}`);
   if (!resp.ok) {
-    logs.push('[LOGS] Python API returned error')
-    return jsonResponse({ error: 'python error', details: data, logs }, resp.status)
+    logs.push("[LOGS] Python API returned error");
+    return jsonResponse(
+      { error: "python error", details: data, logs },
+      resp.status,
+    );
   }
-  logs.push(`[LOGS] Success for campaign ${id}`)
-  const safeData = (data && typeof data === 'object' && !Array.isArray(data)) ? data : { data }
-  return jsonResponse({ ...safeData, logs })
-}
-router.get('/campaigns/:id/logs', campaignLogsHandler)
-router.get('/campaigns/:id/logs/', campaignLogsHandler)
+  logs.push(`[LOGS] Success for campaign ${id}`);
+  const safeData =
+    data && typeof data === "object" && !Array.isArray(data) ? data : { data };
+  return jsonResponse({ ...safeData, logs });
+};
+router.get("/campaigns/:id/logs", campaignLogsHandler);
+router.get("/campaigns/:id/logs/", campaignLogsHandler);
 
 // Get campaign status from Python API (GET, with and without trailing slash)
 const campaignStatusHandler = async ({ params }: { params: any }, env: Env) => {
-  const logs: string[] = []
-  const id = Number(params?.id || 0)
-  logs.push(`[STATUS] Called for campaign id: ${id}`)
+  const logs: string[] = [];
+  const id = Number(params?.id || 0);
+  logs.push(`[STATUS] Called for campaign id: ${id}`);
   if (!id) {
-    logs.push('[STATUS] Invalid id')
-    return jsonResponse({ error: 'invalid id', logs }, 400)
+    logs.push("[STATUS] Invalid id");
+    return jsonResponse({ error: "invalid id", logs }, 400);
   }
-  let resp: Response
+  let resp: Response;
   try {
-    logs.push(`[STATUS] Fetching status from Python API: ${env.PYTHON_API_URL}/campaign_status/${id}`)
-    resp = await fetch(`${env.PYTHON_API_URL}/campaign_status/${id}`)
-    logs.push(`[STATUS] Python API response status: ${resp.status}`)
+    logs.push(
+      `[STATUS] Fetching status from Python API: ${env.PYTHON_API_URL}/campaign_status/${id}`,
+    );
+    resp = await fetch(`${env.PYTHON_API_URL}/campaign_status/${id}`);
+    logs.push(`[STATUS] Python API response status: ${resp.status}`);
   } catch (err) {
-    logs.push(`[STATUS] Fetch error: ${err && ((err as any).stack || (err as any).message || err.toString())}`)
-    return jsonResponse({ error: 'api request failed', logs }, 500)
+    logs.push(
+      `[STATUS] Fetch error: ${err && ((err as any).stack || (err as any).message || err.toString())}`,
+    );
+    return jsonResponse({ error: "api request failed", logs }, 500);
   }
-  const data = await resp.json().catch(e => { logs.push(`[STATUS] JSON parse error: ${e}`); return {} })
-  logs.push(`[STATUS] Python API response data: ${JSON.stringify(data)}`)
+  const data = await resp.json().catch((e) => {
+    logs.push(`[STATUS] JSON parse error: ${e}`);
+    return {};
+  });
+  logs.push(`[STATUS] Python API response data: ${JSON.stringify(data)}`);
   if (!resp.ok) {
-    logs.push('[STATUS] Python API returned error')
-    return jsonResponse({ error: 'python error', details: data, logs }, resp.status)
+    logs.push("[STATUS] Python API returned error");
+    return jsonResponse(
+      { error: "python error", details: data, logs },
+      resp.status,
+    );
   }
-  logs.push(`[STATUS] Success for campaign ${id}`)
-  const safeData = (data && typeof data === 'object' && !Array.isArray(data)) ? data : { data }
-  return jsonResponse({ ...safeData, logs })
-}
-router.get('/campaigns/:id/status', campaignStatusHandler)
-router.get('/campaigns/:id/status/', campaignStatusHandler)
+  logs.push(`[STATUS] Success for campaign ${id}`);
+  const safeData =
+    data && typeof data === "object" && !Array.isArray(data) ? data : { data };
+  return jsonResponse({ ...safeData, logs });
+};
+router.get("/campaigns/:id/status", campaignStatusHandler);
+router.get("/campaigns/:id/status/", campaignStatusHandler);
 
 // Debug endpoint to check recipients and add test data
-router.get('/debug/recipients', async (request: Request, env: Env) => {
-  const url = new URL(request.url)
-  const accountId = Number(url.searchParams.get('account_id') || 1)
-  
-  console.log('GET /debug/recipients for account', accountId)
-  
+router.get("/debug/recipients", async (request: Request, env: Env) => {
+  const url = new URL(request.url);
+  const accountId = Number(url.searchParams.get("account_id") || 1);
+
+  console.log("GET /debug/recipients for account", accountId);
+
   // Check existing recipients
   const existingRecipients = await env.DB.prepare(
-    'SELECT user_phone, category FROM customer_categories WHERE account_id=?1'
-  ).bind(accountId).all()
-  const recipients = Array.isArray(existingRecipients) ? existingRecipients : existingRecipients.results || []
-  
-  console.log('Existing recipients:', recipients)
-  
+    "SELECT user_phone, category FROM customer_categories WHERE account_id=?1",
+  )
+    .bind(accountId)
+    .all();
+  const recipients = Array.isArray(existingRecipients)
+    ? existingRecipients
+    : existingRecipients.results || [];
+
+  console.log("Existing recipients:", recipients);
+
   // If no recipients, add some test data
   if (recipients.length === 0) {
-    console.log('No recipients found, adding test data')
+    console.log("No recipients found, adding test data");
     const testRecipients = [
-      '+1234567890',
-      '+9876543210', 
-      '+5555555555',
-      '+1111111111',
-      '+2222222222'
-    ]
-    
+      "+1234567890",
+      "+9876543210",
+      "+5555555555",
+      "+1111111111",
+      "+2222222222",
+    ];
+
     for (const phone of testRecipients) {
       await env.DB.prepare(
-        'INSERT INTO customer_categories (account_id, user_phone, category, confidence_score) VALUES (?1, ?2, ?3, ?4)'
-      ).bind(accountId, phone, 'test_category', 0.8).run()
+        "INSERT INTO customer_categories (account_id, user_phone, category, confidence_score) VALUES (?1, ?2, ?3, ?4)",
+      )
+        .bind(accountId, phone, "test_category", 0.8)
+        .run();
     }
-    
-    console.log('Added test recipients:', testRecipients)
-    
+
+    console.log("Added test recipients:", testRecipients);
+
     return jsonResponse({
-      message: 'Added test recipients',
+      message: "Added test recipients",
       recipients: testRecipients,
-      account_id: accountId
-    })
+      account_id: accountId,
+    });
   }
-  
+
   return jsonResponse({
-    message: 'Recipients found',
-    recipients: recipients.map((r: any) => ({ phone: r.user_phone, category: r.category })),
+    message: "Recipients found",
+    recipients: recipients.map((r: any) => ({
+      phone: r.user_phone,
+      category: r.category,
+    })),
     count: recipients.length,
-    account_id: accountId
-  })
-})
+    account_id: accountId,
+  });
+});
 
 // Debug endpoint to check campaign details
-router.get('/debug/campaign/:id', async ({ params }, env: Env) => {
-  const id = Number(params?.id || 0)
-  console.log('GET /debug/campaign/:id', id)
-  
-  if (!id) return jsonResponse({ error: 'invalid id' }, 400)
-  
+router.get("/debug/campaign/:id", async ({ params }, env: Env) => {
+  const id = Number(params?.id || 0);
+  console.log("GET /debug/campaign/:id", id);
+
+  if (!id) return jsonResponse({ error: "invalid id" }, 400);
+
   const campaign = await env.DB.prepare(
     `SELECT c.*, t.phone as session_phone, t.encrypted_session_data
      FROM campaigns c 
      LEFT JOIN telegram_sessions t ON c.telegram_session_id=t.id
-     WHERE c.id=?1`
-  ).bind(id).first()
-  
-  if (!campaign) return jsonResponse({ error: 'campaign not found' }, 404)
-  
+     WHERE c.id=?1`,
+  )
+    .bind(id)
+    .first();
+
+  if (!campaign) return jsonResponse({ error: "campaign not found" }, 404);
+
   const recipients = await env.DB.prepare(
-    'SELECT user_phone FROM customer_categories WHERE account_id=?1'
-  ).bind(campaign.account_id).all()
-  const recipientList = Array.isArray(recipients) ? recipients : recipients.results || []
-  
+    "SELECT user_phone FROM customer_categories WHERE account_id=?1",
+  )
+    .bind(campaign.account_id)
+    .all();
+  const recipientList = Array.isArray(recipients)
+    ? recipients
+    : recipients.results || [];
+
   const sentLogs = await env.DB.prepare(
-    'SELECT user_phone, status FROM sent_logs WHERE campaign_id=?1'
-  ).bind(id).all()
-  const sentList = Array.isArray(sentLogs) ? sentLogs : sentLogs.results || []
-  
+    "SELECT user_phone, status FROM sent_logs WHERE campaign_id=?1",
+  )
+    .bind(id)
+    .all();
+  const sentList = Array.isArray(sentLogs) ? sentLogs : sentLogs.results || [];
+
   return jsonResponse({
     campaign: {
       id: campaign.id,
@@ -753,55 +908,61 @@ router.get('/debug/campaign/:id', async ({ params }, env: Env) => {
       status: campaign.status,
       telegram_session_id: campaign.telegram_session_id,
       session_phone: campaign.session_phone,
-      has_session_data: !!campaign.encrypted_session_data
+      has_session_data: !!campaign.encrypted_session_data,
     },
     recipients: {
       total: recipientList.length,
-      phones: recipientList.map((r: any) => r.user_phone)
+      phones: recipientList.map((r: any) => r.user_phone),
     },
     sent_logs: {
       total: sentList.length,
-      sent: sentList.filter((r: any) => r.status === 'sent').length,
-      failed: sentList.filter((r: any) => r.status !== 'sent').length,
-      logs: sentList
-    }
-  })
-})
+      sent: sentList.filter((r: any) => r.status === "sent").length,
+      failed: sentList.filter((r: any) => r.status !== "sent").length,
+      logs: sentList,
+    },
+  });
+});
 
 // Add a /test endpoint for deployment debugging
-router.all('/test', (request: Request) => {
-  return jsonResponse({ ok: true, method: request.method, url: request.url })
-})
+router.all("/test", (request: Request) => {
+  return jsonResponse({ ok: true, method: request.method, url: request.url });
+});
 
 // Add a catch-all logger for unmatched routes
-router.all('*', (request: Request) => {
-  const logs = [`[CATCH-ALL] Unmatched route: ${request.method} ${request.url}`]
-  return jsonResponse({ error: 'Not Found', logs }, 404)
-})
+router.all("*", (request: Request) => {
+  const logs = [
+    `[CATCH-ALL] Unmatched route: ${request.method} ${request.url}`,
+  ];
+  return jsonResponse({ error: "Not Found", logs }, 404);
+});
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    if (request.method === 'OPTIONS') {
-      return new Response('', { status: 204, headers: corsHeaders })
+    if (request.method === "OPTIONS") {
+      return new Response("", { status: 204, headers: corsHeaders });
     }
 
-    await ensureSchema(env.DB)
+    await ensureSchema(env.DB);
 
-    console.log('incoming request', request.method, new URL(request.url).pathname)
+    console.log(
+      "incoming request",
+      request.method,
+      new URL(request.url).pathname,
+    );
 
-    let resp: Response
+    let resp: Response;
     try {
-      resp = await router.handle(request, env, ctx)
+      resp = await router.handle(request, env, ctx);
       if (!resp) {
-        resp = new Response('Not Found', { status: 404 })
+        resp = new Response("Not Found", { status: 404 });
       }
     } catch (err) {
-      console.error('router error', err)
-      resp = new Response('Internal Error', { status: 500 })
+      console.error("router error", err);
+      resp = new Response("Internal Error", { status: 500 });
     }
-    resp.headers.set('Access-Control-Allow-Origin', '*')
-    resp.headers.set('Access-Control-Allow-Headers', 'Content-Type')
-    resp.headers.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
-    return resp
-  }
-}
+    resp.headers.set("Access-Control-Allow-Origin", "*");
+    resp.headers.set("Access-Control-Allow-Headers", "Content-Type");
+    resp.headers.set("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    return resp;
+  },
+};


### PR DESCRIPTION
## Summary
- allow setting recipient limit when launching campaigns
- propagate limit through worker to python API
- compute success rate and progress using new limit
- improve live log formatting and monitoring UI prompt

## Testing
- `pip install requests`
- `bash tests/run_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_686aaed2d4fc832fbc688233db17b5ef