### PR TITLE
Move categorization to Python API

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -559,12 +559,6 @@ router.post("/campaigns/:id/start", async ({ params, request }, env: Env) => {
     return jsonResponse({ error: "no session data found" }, 400);
   }
 
-  // Categorize users based on chat history before sending
-  try {
-    await categorizeChats(env, row.account_id, row.encrypted_session_data);
-  } catch (e) {
-    console.error("categorizeChats error", e);
-  }
 
   let limit: number | undefined;
   try {
@@ -623,6 +617,9 @@ router.post("/campaigns/:id/start", async ({ params, request }, env: Env) => {
 
   const data = await resp.json().catch(() => ({}));
   console.log("execute_campaign response data:", data);
+  if (data && data.categorization) {
+    console.log("categorization summary from python", data.categorization);
+  }
   if (!resp.ok) {
     console.error("Python API returned error:", data);
     return jsonResponse({ error: "python error", details: data }, resp.status);
@@ -724,6 +721,9 @@ router.post("/campaigns/:id/update", async ({ params, request }, env: Env) => {
     });
     
     const data = await resp.json();
+    if (data && data.categorization) {
+      console.log("categorization summary from python", data.categorization);
+    }
     if (!resp.ok) {
       return jsonResponse({ error: "python error", details: data }, resp.status);
     }
@@ -749,13 +749,7 @@ router.post("/campaigns/:id/resume", async ({ params }, env: Env) => {
       .first();
   } catch {}
 
-  if (row && row.encrypted_session_data) {
-    try {
-      await categorizeChats(env, row.account_id, row.encrypted_session_data);
-    } catch (e) {
-      console.error("categorizeChats error", e);
-    }
-  }
+  // Categorization now handled by Python API
 
   try {
     const resp = await fetch(`${env.PYTHON_API_URL}/resume_campaign/${id}`, {
@@ -871,6 +865,53 @@ router.delete("/categories/:id", async ({ params }: any, env: Env) => {
     .bind(id, accountId)
     .run();
   return jsonResponse({ id, deleted: true });
+});
+
+// Receive categorization results from Python API
+router.post("/categorize", async (request: Request, env: Env) => {
+  const { account_id, matches } = (await request.json()) as any;
+  const logs: string[] = [];
+  const accountId = Number(account_id || 0);
+  if (!accountId || !Array.isArray(matches)) {
+    logs.push("invalid parameters");
+    return jsonResponse({ error: "invalid parameters", logs }, 400);
+  }
+  let updated = 0;
+  for (const m of matches) {
+    const phone = m?.phone;
+    const category = m?.category;
+    const score = Number(m?.score ?? 0.8);
+    if (!phone || !category) {
+      logs.push(`[skip] missing data for ${JSON.stringify(m)}`);
+      continue;
+    }
+    try {
+      const existing = await env.DB.prepare(
+        "SELECT id FROM customer_categories WHERE account_id=?1 AND user_phone=?2 AND category=?3",
+      )
+        .bind(accountId, phone, category)
+        .first();
+      if (existing && existing.id) {
+        await env.DB.prepare(
+          "UPDATE customer_categories SET confidence_score=?1 WHERE id=?2",
+        )
+          .bind(score, existing.id)
+          .run();
+        logs.push(`[update] ${phone} -> ${category}`);
+      } else {
+        await env.DB.prepare(
+          "INSERT INTO customer_categories (account_id, user_phone, category, confidence_score) VALUES (?1, ?2, ?3, ?4)",
+        )
+          .bind(accountId, phone, category, score)
+          .run();
+        logs.push(`[insert] ${phone} -> ${category}`);
+      }
+      updated++;
+    } catch (e) {
+      logs.push(`[error] ${phone}/${category} ${(e as any).message}`);
+    }
+  }
+  return jsonResponse({ updated, logs });
 });
 
 // Analytics summary


### PR DESCRIPTION
## Summary
- fetch category data in Python API
- categorize chats when executing or resuming campaigns
- send categorization results back to the worker
- add /categorize endpoint in worker
- log categorization summaries in worker when starting/resuming campaigns

## Testing
- `pip install requests`
- `bash tests/run_all.sh` *(fails: Could not connect to Python API)*

------
https://chatgpt.com/codex/tasks/task_e_686d11daa1f8832f80b63cb3c768c09b