### PR TITLE
Implement refined monitoring and counts

### DIFF
--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -6,7 +6,6 @@ const API_BASE =
 
 export default function CampaignMonitor({ accountId }) {
   const [progress, setProgress] = useState(0)
-  const [errors, setErrors] = useState([])
   const [logs, setLogs] = useState([])
   const [running, setRunning] = useState([])
   const [activeId, setActiveId] = useState(null)
@@ -81,12 +80,6 @@ export default function CampaignMonitor({ accountId }) {
           setProgress(0)
         }
         
-        // Update errors from status
-        if (data.failed_count > 0) {
-          setErrors([`${data.failed_count} messages failed to send`])
-        } else {
-          setErrors([])
-        }
       } else {
         console.error('Failed to fetch campaign status:', data.error)
       }
@@ -103,11 +96,6 @@ export default function CampaignMonitor({ accountId }) {
       if (response.ok) {
         const formattedLogs = Array.isArray(data.logs) ? data.logs : []
         setLogs(formattedLogs)
-        // Remove any logic that sets progress from logs
-        // Only update errors from logs
-        const failedLogs = formattedLogs.filter(l => l.status !== 'sent')
-        const errorMessages = failedLogs.map(l => `${l.phone}: ${l.error || 'failed'}`)
-        setErrors(errorMessages)
       } else {
         console.error('Failed to fetch campaign logs:', data.error)
       }
@@ -334,18 +322,6 @@ export default function CampaignMonitor({ accountId }) {
               </div>
             </div>
 
-            <div>
-              <h3 className="font-medium mb-1">Error Notifications</h3>
-              {errors.length === 0 ? (
-                <p className="text-sm text-gray-500">No errors</p>
-              ) : (
-                <ul className="list-disc list-inside text-sm text-red-600 space-y-1">
-                  {errors.map((e, i) => (
-                    <li key={i}>{e}</li>
-                  ))}
-                </ul>
-              )}
-            </div>
 
             <div>
               <h3 className="font-medium mb-1">Live Logs</h3>

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -571,6 +571,7 @@ router.post("/campaigns/:id/start", async ({ params, request }, env: Env) => {
     limit = Number(filters.limit);
     if (!Number.isFinite(limit) || limit <= 0) limit = undefined;
   }
+  const targetRecipients = limit;
 
   // Log the request being sent to Python API
   const requestBody = {
@@ -579,6 +580,7 @@ router.post("/campaigns/:id/start", async ({ params, request }, env: Env) => {
     account_id: row.account_id,
     campaign_id: row.id,
     ...(limit ? { limit } : {}),
+    ...(targetRecipients ? { target_recipients: targetRecipients } : {}),
     ...filters,
   };
   console.log("Sending to Python API:", {


### PR DESCRIPTION
## Summary
- worker forwards target recipients to Python API when starting campaigns
- python API tracks target recipient counts and filters logs
- frontend simplifies campaign monitor by focusing on send logs

## Testing
- `pip install requests`
- `bash tests/run_all.sh` *(fails: Could not connect to Python API)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc46a430833188677f0d973338ce