### PR TITLE
Handle early campaign completion

### DIFF
--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -258,7 +258,11 @@ export default function CampaignMonitor({ accountId }) {
                         disabled={loading}
                         className="px-2 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
                       >
-                        {loading ? 'Resuming...' : 'Resume'}
+                        {loading
+                          ? 'Resuming...'
+                          : c.status === 'completed'
+                          ? 'Retry'
+                          : 'Resume'}
                       </button>
                     ) : (
                       <button
@@ -295,6 +299,10 @@ export default function CampaignMonitor({ accountId }) {
               <p className="text-xs text-gray-500 mb-2">
                 {progress > 0 ? `${progress}% complete` : 'Not started'}
               </p>
+
+              {campaignStatus.status === 'completed' && (
+                <p className="text-green-600 text-sm font-semibold">Campaign finished</p>
+              )}
 
               <div className="flex items-center justify-between mt-1">
                 <div className="text-xs text-gray-500">

--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -133,7 +133,11 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
                   className="px-2 py-1 text-sm bg-green-600 text-white rounded"
                   onClick={() => startCampaign(c.id)}
                 >
-                  {c.status === "stopped" ? "Resume" : "Run"}
+                  {c.status === "stopped"
+                    ? "Resume"
+                    : c.status === "completed"
+                    ? "Retry"
+                    : "Run"}
                 </button>
               )}
             </div>

--- a/python_api/main.py
+++ b/python_api/main.py
@@ -742,7 +742,8 @@ def execute_campaign():
         # Update final status
         CAMPAIGN_STATUS[campaign_id]['current_recipient'] = None
         CAMPAIGN_STATUS[campaign_id]['completed_at'] = datetime.now().isoformat()
-
+        if processed_dialogs < CAMPAIGN_STATUS[campaign_id].get('total_recipients', processed_dialogs):
+            CAMPAIGN_STATUS[campaign_id]['total_recipients'] = processed_dialogs
         if stopped or CAMPAIGN_STATUS[campaign_id].get('status') == 'stopped':
             CAMPAIGN_STATUS[campaign_id]['status'] = 'stopped'
             log_campaign_event(campaign_id, 'campaign_stopped', {
@@ -1344,6 +1345,8 @@ async def _resume_send(campaign_id):
         # Update final status
         CAMPAIGN_STATUS[campaign_id]['current_recipient'] = None
         CAMPAIGN_STATUS[campaign_id]['completed_at'] = datetime.now().isoformat()
+        if processed_dialogs < CAMPAIGN_STATUS[campaign_id].get('total_recipients', processed_dialogs):
+            CAMPAIGN_STATUS[campaign_id]['total_recipients'] = processed_dialogs
 
         if STOP_FLAGS.get(campaign_id):
             CAMPAIGN_STATUS[campaign_id]['status'] = 'stopped'

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1176,6 +1176,16 @@ const campaignStatusHandler = async ({ params }: { params: any }, env: Env) => {
   logs.push(`[STATUS] Success for campaign ${id}`);
   const safeData =
     data && typeof data === "object" && !Array.isArray(data) ? data : { data };
+  if (safeData.status && safeData.status !== "running") {
+    try {
+      await env.DB.prepare("UPDATE campaigns SET status=?1 WHERE id=?2")
+        .bind(safeData.status, id)
+        .run();
+      logs.push(`[STATUS] Updated campaign ${id} status to ${safeData.status}`);
+    } catch (e) {
+      logs.push(`[STATUS] DB update error: ${e}`);
+    }
+  }
   return jsonResponse({ ...safeData, logs });
 };
 router.get("/campaigns/:id/status", campaignStatusHandler);


### PR DESCRIPTION
## Summary
- adjust Python API to mark campaigns complete when all eligible chats processed
- update worker to persist completion status in the DB
- show completion indicator and retry buttons in the UI

## Testing
- `python -m py_compile python_api/main.py`
- `./tests/run_all.sh` *(fails: Could not connect to Python API)*

------
https://chatgpt.com/codex/tasks/task_e_6873a894a0b08331a7c26ab934707095