### PR TITLE
Handle early campaign completion

### DIFF
--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -73,8 +73,12 @@ export default function CampaignMonitor({ accountId }) {
       
       if (response.ok) {
         setCampaignStatus(data)
-        // Defensive: Only set progress if total_recipients > 0
-        if (typeof data.progress_percent === 'number' && data.total_recipients > 0) {
+        if (data.status === 'completed') {
+          setProgress(100)
+        } else if (
+          typeof data.progress_percent === 'number' &&
+          data.total_recipients > 0
+        ) {
           setProgress(data.progress_percent)
         } else {
           setProgress(0)
@@ -249,7 +253,7 @@ export default function CampaignMonitor({ accountId }) {
                     >
                       Edit
                     </button>
-                    {c.status === 'stopped' || c.status === 'completed' ? (
+                    {c.status === 'stopped' ? (
                       <button
                         onClick={(e) => {
                           e.stopPropagation()
@@ -260,6 +264,8 @@ export default function CampaignMonitor({ accountId }) {
                       >
                         {loading ? 'Resuming...' : 'Resume'}
                       </button>
+                    ) : c.status === 'completed' ? (
+                      <span className="px-2 py-1 text-xs bg-gray-300 text-gray-700 rounded">Completed</span>
                     ) : (
                       <button
                         onClick={(e) => {
@@ -295,6 +301,13 @@ export default function CampaignMonitor({ accountId }) {
               <p className="text-xs text-gray-500 mb-2">
                 {progress > 0 ? `${progress}% complete` : 'Not started'}
               </p>
+
+              {campaignStatus.status === 'completed' && (
+                <p className="text-green-600 text-sm font-semibold">Campaign finished</p>
+              )}
+              {campaignStatus.status === 'running' && campaignStatus.neglected_count > 0 && (
+                <p className="text-orange-600 text-xs">Neglecting {campaignStatus.neglected_count} chats</p>
+              )}
 
               <div className="flex items-center justify-between mt-1">
                 <div className="text-xs text-gray-500">

--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -129,12 +129,16 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
                   </button>
                 </>
               ) : (
-                <button
-                  className="px-2 py-1 text-sm bg-green-600 text-white rounded"
-                  onClick={() => startCampaign(c.id)}
-                >
-                  {c.status === "stopped" ? "Resume" : "Run"}
-                </button>
+                {c.status === "completed" ? (
+                  <span className="px-2 py-1 text-sm bg-gray-300 text-gray-700 rounded">Completed</span>
+                ) : (
+                  <button
+                    className="px-2 py-1 text-sm bg-green-600 text-white rounded"
+                    onClick={() => startCampaign(c.id)}
+                  >
+                    {c.status === "stopped" ? "Resume" : "Run"}
+                  </button>
+                )}
               )}
             </div>
           </li>

--- a/python_api/main.py
+++ b/python_api/main.py
@@ -449,7 +449,8 @@ def execute_campaign():
         'total_recipients': target_recipients if isinstance(target_recipients, int) else (limit if isinstance(limit, int) else 0),
         'sent_count': 0,
         'failed_count': 0,
-        'current_recipient': None
+        'current_recipient': None,
+        'neglected_count': 0
     }
     STOP_FLAGS[campaign_id] = False
 
@@ -504,10 +505,12 @@ def execute_campaign():
                 break
             try:
                 if not dialog.is_user:
+                    CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                     continue
 
                 user = dialog.entity
                 if user.bot:
+                    CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                     continue
 
                 # Get chat start and newest message times
@@ -526,8 +529,10 @@ def execute_campaign():
                             if filter_dt.tzinfo:
                                 filter_dt = filter_dt.replace(tzinfo=None)
                             if chat_start_time_cmp == 'after' and chat_start_dt < filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                             if chat_start_time_cmp == 'before' and chat_start_dt > filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                     except Exception as e:
                         print(f"[ERROR] chat_start_time filter: {e}")
@@ -543,8 +548,10 @@ def execute_campaign():
                             if filter_dt.tzinfo:
                                 filter_dt = filter_dt.replace(tzinfo=None)
                             if newest_chat_time_cmp == 'after' and newest_dt < filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                             if newest_chat_time_cmp == 'before' and newest_dt > filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                     except Exception as e:
                         print(f"[ERROR] newest_chat_time filter: {e}")
@@ -584,12 +591,14 @@ def execute_campaign():
                                 'recipient': f"{user.username or user.id}",
                                 'matches': []
                             })
+                            CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                             continue
                     elif not match_set.intersection(include_categories):
                         log_campaign_event(campaign_id, 'category_filtered', {
                             'recipient': f"{user.username or user.id}",
                             'matches': list(match_set)
                         })
+                        CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                         continue
 
                 if exclude_categories:
@@ -598,12 +607,14 @@ def execute_campaign():
                             'recipient': f"{user.username or user.id}",
                             'matches': []
                         })
+                        CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                         continue
                     if match_set.intersection(exclude_categories):
                         log_campaign_event(campaign_id, 'category_filtered', {
                             'recipient': f"{user.username or user.id}",
                             'matches': list(match_set)
                         })
+                        CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                         continue
 
                 try:
@@ -742,7 +753,8 @@ def execute_campaign():
         # Update final status
         CAMPAIGN_STATUS[campaign_id]['current_recipient'] = None
         CAMPAIGN_STATUS[campaign_id]['completed_at'] = datetime.now().isoformat()
-
+        if processed_dialogs < CAMPAIGN_STATUS[campaign_id].get('total_recipients', processed_dialogs):
+            CAMPAIGN_STATUS[campaign_id]['total_recipients'] = processed_dialogs
         if stopped or CAMPAIGN_STATUS[campaign_id].get('status') == 'stopped':
             CAMPAIGN_STATUS[campaign_id]['status'] = 'stopped'
             log_campaign_event(campaign_id, 'campaign_stopped', {
@@ -975,6 +987,9 @@ def get_campaign_status(campaign_id):
     else:
         progress_percent = 0
 
+    if status.get('status') == 'completed':
+        progress_percent = 100
+
 
     if processed > 0:
         success_rate = (sent_count / processed) * 100
@@ -992,6 +1007,7 @@ def get_campaign_status(campaign_id):
         'total_recipients': total_recipients,
         'sent_count': sent_count,
         'failed_count': failed_count,
+        'neglected_count': status.get('neglected_count', 0),
         'success_rate': f"{success_rate:.1f}%",
         'current_recipient': status.get('current_recipient'),
         'started_at': status.get('started_at'),
@@ -1120,7 +1136,8 @@ def resume_campaign(campaign_id):
         'sent_count': status.get('sent_count', 0),  # Keep existing sent count
         'failed_count': status.get('failed_count', 0),  # Keep existing failed count
         'current_recipient': None,
-        'is_resumed': True
+        'is_resumed': True,
+        'neglected_count': status.get('neglected_count', 0)
     }
     
     log_campaign_event(campaign_id, 'campaign_resumed', {
@@ -1207,16 +1224,19 @@ async def _resume_send(campaign_id):
                 
             try:
                 if not dialog.is_user:
+                    CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                     continue
 
                 user = dialog.entity
                 if user.bot:
+                    CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                     continue
 
                 # Skip users that have already been sent messages
                 user_id = str(user.id)
                 if user_id in sent_users:
                     print(f"[DEBUG] Skipping already sent user: {user.username or user.id}")
+                    CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                     continue
 
                 # Get chat start and newest message times
@@ -1235,8 +1255,10 @@ async def _resume_send(campaign_id):
                             if filter_dt.tzinfo:
                                 filter_dt = filter_dt.replace(tzinfo=None)
                             if campaign_data['chat_start_time_cmp'] == 'after' and chat_start_dt < filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                             if campaign_data['chat_start_time_cmp'] == 'before' and chat_start_dt > filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                     except Exception as e:
                         print(f"[ERROR] chat_start_time filter: {e}")
@@ -1252,8 +1274,10 @@ async def _resume_send(campaign_id):
                             if filter_dt.tzinfo:
                                 filter_dt = filter_dt.replace(tzinfo=None)
                             if campaign_data['newest_chat_time_cmp'] == 'after' and newest_dt < filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                             if campaign_data['newest_chat_time_cmp'] == 'before' and newest_dt > filter_dt:
+                                CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                                 continue
                     except Exception as e:
                         print(f"[ERROR] newest_chat_time filter: {e}")
@@ -1281,12 +1305,14 @@ async def _resume_send(campaign_id):
                                 'recipient': f"{user.username or user.id}",
                                 'matches': []
                             })
+                            CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                             continue
                     elif not match_set.intersection(include_categories):
                         log_campaign_event(campaign_id, 'category_filtered', {
                             'recipient': f"{user.username or user.id}",
                             'matches': list(match_set)
                         })
+                        CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                         continue
 
                 if exclude_categories:
@@ -1295,12 +1321,14 @@ async def _resume_send(campaign_id):
                             'recipient': f"{user.username or user.id}",
                             'matches': []
                         })
+                        CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                         continue
                     if match_set.intersection(exclude_categories):
                         log_campaign_event(campaign_id, 'category_filtered', {
                             'recipient': f"{user.username or user.id}",
                             'matches': list(match_set)
                         })
+                        CAMPAIGN_STATUS[campaign_id]['neglected_count'] += 1
                         continue
 
                 try:
@@ -1344,6 +1372,8 @@ async def _resume_send(campaign_id):
         # Update final status
         CAMPAIGN_STATUS[campaign_id]['current_recipient'] = None
         CAMPAIGN_STATUS[campaign_id]['completed_at'] = datetime.now().isoformat()
+        if processed_dialogs < CAMPAIGN_STATUS[campaign_id].get('total_recipients', processed_dialogs):
+            CAMPAIGN_STATUS[campaign_id]['total_recipients'] = processed_dialogs
 
         if STOP_FLAGS.get(campaign_id):
             CAMPAIGN_STATUS[campaign_id]['status'] = 'stopped'

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1176,6 +1176,16 @@ const campaignStatusHandler = async ({ params }: { params: any }, env: Env) => {
   logs.push(`[STATUS] Success for campaign ${id}`);
   const safeData =
     data && typeof data === "object" && !Array.isArray(data) ? data : { data };
+  if (safeData.status && safeData.status !== "running") {
+    try {
+      await env.DB.prepare("UPDATE campaigns SET status=?1 WHERE id=?2")
+        .bind(safeData.status, id)
+        .run();
+      logs.push(`[STATUS] Updated campaign ${id} status to ${safeData.status}`);
+    } catch (e) {
+      logs.push(`[STATUS] DB update error: ${e}`);
+    }
+  }
   return jsonResponse({ ...safeData, logs });
 };
 router.get("/campaigns/:id/status", campaignStatusHandler);


### PR DESCRIPTION
## Summary
- track neglected chats in campaign status
- mark progress 100% on completion
- display completion state and neglected count in UI

## Testing
- `python -m py_compile python_api/main.py`
- `./tests/run_all.sh` *(fails: Could not connect to Python API)*

------
https://chatgpt.com/codex/tasks/task_e_6873a894a0b08331a7c26ab934707095