### PR TITLE
Handle early campaign completion

### DIFF
--- a/CAMPAIGN_EDITING_FEATURES.md
+++ b/CAMPAIGN_EDITING_FEATURES.md
@@ -1,57 +1,19 @@
-# Campaign Editing and Resuming Features
+# Campaign Resuming Features
 
-This document describes the new campaign editing and resuming functionality that has been implemented in the retargeting system.
+This document describes the campaign resuming functionality implemented in the retargeting system.
 
 ## Overview
 
 The system now supports:
-1. **Campaign Editing**: Users can edit campaign parameters (message, limit) at any time
-2. **Campaign Resuming**: Users can resume stopped campaigns, with automatic exclusion of already sent users
-3. **User Tracking**: The system tracks which users have been sent messages to avoid duplicates
+1. **Campaign Resuming**: Users can resume stopped campaigns, with automatic exclusion of already sent users
+2. **User Tracking**: The system tracks which users have been sent messages to avoid duplicates
+
+> **Note**: The campaign editing routes (`/campaign_data` and `/update_campaign`) have been removed.
 
 ## New API Endpoints
 
 ### Python API (`python_api/main.py`)
 
-#### 1. Get Campaign Data
-```
-GET /campaign_data/<campaign_id>
-```
-Returns campaign configuration data for editing purposes.
-
-**Response:**
-```json
-{
-  "campaign_id": 123,
-  "data": {
-    "message": "Campaign message",
-    "limit": 100,
-    "account_id": 1,
-    "session": "session_string",
-    "created_at": "2024-01-01T12:00:00"
-  },
-  "status": "running",
-  "sent_count": 50,
-  "failed_count": 5,
-  "total_recipients": 100
-}
-```
-
-#### 2. Update Campaign
-```
-POST /update_campaign/<campaign_id>
-```
-Updates campaign configuration data.
-
-**Request Body:**
-```json
-{
-  "message": "Updated message",
-  "limit": 150,
-  "account_id": 1,
-  "session": "session_string"
-}
-```
 
 #### 3. Resume Campaign
 ```
@@ -61,10 +23,8 @@ Resumes a stopped campaign, excluding users that have already been sent messages
 
 ## Worker API (`worker/src/index.ts`)
 
-The worker API now includes proxy endpoints for the new Python API functionality:
+The worker API exposes a resume endpoint that proxies to the Python API:
 
-- `GET /campaigns/:id/data` - Get campaign data
-- `POST /campaigns/:id/update` - Update campaign data  
 - `POST /campaigns/:id/resume` - Resume campaign
 
 ## Frontend Components
@@ -73,13 +33,9 @@ The worker API now includes proxy endpoints for the new Python API functionality
 
 The campaign monitor now includes:
 
-1. **Edit Button**: Allows editing of any campaign
-2. **Resume Button**: Shows for stopped/completed campaigns
-3. **Edit Modal**: Modal dialog for editing campaign parameters
-4. **Enhanced Campaign List**: Shows all campaigns (running, stopped, completed)
+1. **Resume Button**: Shows for stopped/completed campaigns
+2. **Enhanced Campaign List**: Shows all campaigns (running, stopped, completed)
 
-**New Features:**
-- Campaign editing modal with message and limit fields
 - Resume functionality for stopped campaigns
 - Real-time status updates
 - Error handling and user feedback
@@ -89,7 +45,6 @@ The campaign monitor now includes:
 Updated to show:
 - Campaign status in the existing campaigns list
 - Resume button for stopped campaigns
-- Edit button that navigates to campaign monitor
 
 ## How It Works
 
@@ -107,13 +62,6 @@ When resuming a campaign:
 2. During recipient collection, it skips users whose IDs are in the sent users set
 3. Only new users receive the message
 
-### Campaign Editing Flow
-
-1. User clicks "Edit" button on a campaign
-2. System fetches current campaign data via `/campaigns/:id/data`
-3. User modifies message and/or limit in the modal
-4. System updates campaign data via `/campaigns/:id/update`
-5. Campaign continues with updated parameters
 
 ### Campaign Resuming Flow
 

--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -12,8 +12,6 @@ export default function CampaignMonitor({ accountId }) {
   const [campaignStatus, setCampaignStatus] = useState({})
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
-  const [showEditModal, setShowEditModal] = useState(false)
-  const [editingCampaign, setEditingCampaign] = useState(null)
   const initialMount = React.useRef(true)
 
   const stopCampaign = async (id) => {
@@ -73,8 +71,12 @@ export default function CampaignMonitor({ accountId }) {
       
       if (response.ok) {
         setCampaignStatus(data)
-        // Defensive: Only set progress if total_recipients > 0
-        if (typeof data.progress_percent === 'number' && data.total_recipients > 0) {
+        if (data.status === 'completed') {
+          setProgress(100)
+        } else if (
+          typeof data.progress_percent === 'number' &&
+          data.total_recipients > 0
+        ) {
           setProgress(data.progress_percent)
         } else {
           setProgress(0)
@@ -162,46 +164,6 @@ export default function CampaignMonitor({ accountId }) {
     }
   }
 
-  const editCampaign = async (id) => {
-    try {
-      const response = await fetch(`${API_BASE}/campaigns/${id}/data`)
-      const data = await response.json()
-      if (response.ok) {
-        setEditingCampaign(data)
-        setShowEditModal(true)
-      } else {
-        setError(`Failed to get campaign data: ${data.error || 'Unknown error'}`)
-      }
-    } catch (e) {
-      console.error('get campaign data error:', e)
-      setError(`Failed to get campaign data: ${e.message}`)
-    }
-  }
-
-  const updateCampaign = async (campaignId, updatedData) => {
-    setLoading(true)
-    try {
-      const response = await fetch(`${API_BASE}/campaigns/${campaignId}/update`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updatedData)
-      })
-      const data = await response.json()
-      if (response.ok) {
-        setShowEditModal(false)
-        setEditingCampaign(null)
-        // Refresh campaign status
-        fetchCampaignStatus(campaignId)
-      } else {
-        setError(`Failed to update campaign: ${data.error || 'Unknown error'}`)
-      }
-    } catch (e) {
-      console.error('update campaign error:', e)
-      setError(`Failed to update campaign: ${e.message}`)
-    } finally {
-      setLoading(false)
-    }
-  }
 
   return (
     <div className="p-4 space-y-4">
@@ -240,16 +202,7 @@ export default function CampaignMonitor({ accountId }) {
                     <p className="text-xs text-gray-500">Status: {c.status}</p>
                   </div>
                   <div className="flex gap-1 ml-2">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        editCampaign(c.id)
-                      }}
-                      className="px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
-                    >
-                      Edit
-                    </button>
-                    {c.status === 'stopped' || c.status === 'completed' ? (
+                    {c.status === 'stopped' ? (
                       <button
                         onClick={(e) => {
                           e.stopPropagation()
@@ -260,6 +213,8 @@ export default function CampaignMonitor({ accountId }) {
                       >
                         {loading ? 'Resuming...' : 'Resume'}
                       </button>
+                    ) : c.status === 'completed' ? (
+                      <span className="px-2 py-1 text-xs bg-gray-300 text-gray-700 rounded">Completed</span>
                     ) : (
                       <button
                         onClick={(e) => {
@@ -295,6 +250,13 @@ export default function CampaignMonitor({ accountId }) {
               <p className="text-xs text-gray-500 mb-2">
                 {progress > 0 ? `${progress}% complete` : 'Not started'}
               </p>
+
+              {campaignStatus.status === 'completed' && (
+                <p className="text-green-600 text-sm font-semibold">Campaign finished</p>
+              )}
+              {campaignStatus.status === 'running' && campaignStatus.neglected_count > 0 && (
+                <p className="text-orange-600 text-xs">Neglecting {campaignStatus.neglected_count} chats</p>
+              )}
 
               <div className="flex items-center justify-between mt-1">
                 <div className="text-xs text-gray-500">
@@ -341,70 +303,6 @@ export default function CampaignMonitor({ accountId }) {
                   </ul>
                 </div>
               )}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Edit Campaign Modal */}
-      {showEditModal && editingCampaign && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded-lg max-w-md w-full mx-4">
-            <h3 className="text-lg font-semibold mb-4">Edit Campaign #{editingCampaign.campaign_id}</h3>
-            
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">Message</label>
-                <textarea
-                  value={editingCampaign.data?.message || ''}
-                  onChange={(e) => setEditingCampaign({
-                    ...editingCampaign,
-                    data: { ...editingCampaign.data, message: e.target.value }
-                  })}
-                  className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  rows={4}
-                />
-              </div>
-              
-              <div>
-                <label className="block text-sm font-medium mb-1">Limit (optional)</label>
-                <input
-                  type="number"
-                  value={editingCampaign.data?.limit || ''}
-                  onChange={(e) => setEditingCampaign({
-                    ...editingCampaign,
-                    data: { ...editingCampaign.data, limit: e.target.value ? parseInt(e.target.value) : null }
-                  })}
-                  className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="Leave empty for no limit"
-                />
-              </div>
-              
-              <div className="text-sm text-gray-600">
-                <p><strong>Current Status:</strong> {editingCampaign.status}</p>
-                <p><strong>Sent:</strong> {editingCampaign.sent_count}</p>
-                <p><strong>Failed:</strong> {editingCampaign.failed_count}</p>
-                <p><strong>Total Recipients:</strong> {editingCampaign.total_recipients}</p>
-              </div>
-            </div>
-            
-            <div className="flex gap-2 mt-6">
-              <button
-                onClick={() => {
-                  setShowEditModal(false)
-                  setEditingCampaign(null)
-                }}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded hover:bg-gray-50"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => updateCampaign(editingCampaign.campaign_id, editingCampaign.data)}
-                disabled={loading}
-                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-              >
-                {loading ? 'Updating...' : 'Update Campaign'}
-              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/Campaigns.jsx
+++ b/frontend/src/components/Campaigns.jsx
@@ -14,6 +14,23 @@ function stripPTags(html) {
   return html.replace(/^<p>(.*?)<\/p>$/is, '$1');
 }
 
+function summarizeFilters(json) {
+  try {
+    const f = JSON.parse(json);
+    const parts = [];
+    if (f.limit) parts.push(`limit ${f.limit}`);
+    if (f.include_categories && f.include_categories.length) {
+      parts.push(`include ${f.include_categories.join(',')}`);
+    }
+    if (f.exclude_categories && f.exclude_categories.length) {
+      parts.push(`exclude ${f.exclude_categories.join(',')}`);
+    }
+    return parts.join('; ');
+  } catch {
+    return '';
+  }
+}
+
 export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
   const [campaigns, setCampaigns] = useState([]);
   const [showForm, setShowForm] = useState(false);
@@ -104,7 +121,7 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
               </p>
               <div className="text-sm text-gray-600" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(stripPTags(c.message_text)).slice(0, 120) + (c.message_text.length > 120 ? '...' : '') }} />
               {c.filters_json && (
-                <pre className="text-xs text-gray-400 mt-1">{c.filters_json}</pre>
+                <p className="text-xs text-gray-400 mt-1 break-words">{summarizeFilters(c.filters_json)}</p>
               )}
             </div>
             <div className="flex items-center gap-4">
@@ -129,12 +146,16 @@ export default function Campaigns({ accountId, sessionId, onSelectCampaign }) {
                   </button>
                 </>
               ) : (
-                <button
-                  className="px-2 py-1 text-sm bg-green-600 text-white rounded"
-                  onClick={() => startCampaign(c.id)}
-                >
-                  {c.status === "stopped" ? "Resume" : "Run"}
-                </button>
+                {c.status === "completed" ? (
+                  <span className="px-2 py-1 text-sm bg-gray-300 text-gray-700 rounded">Completed</span>
+                ) : (
+                  <button
+                    className="px-2 py-1 text-sm bg-green-600 text-white rounded"
+                    onClick={() => startCampaign(c.id)}
+                  >
+                    {c.status === "stopped" ? "Resume" : "Run"}
+                  </button>
+                )}
               )}
             </div>
           </li>

--- a/tests/test_campaign_editing.py
+++ b/tests/test_campaign_editing.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """
-Test campaign editing and resuming functionality
+Test campaign resuming functionality
 """
 
 import requests
 import json
-import time
 
 # Configuration
 PYTHON_API_URL = "http://localhost:5000"
@@ -13,7 +12,7 @@ PYTHON_API_URL = "http://localhost:5000"
 def test_campaign_editing_and_resuming():
     """Test the complete flow of campaign editing and resuming."""
     
-    print("Testing campaign editing and resuming functionality...")
+    print("Testing campaign resuming functionality without edit route...")
     
     # Test data
     test_campaign_data = {
@@ -38,39 +37,18 @@ def test_campaign_editing_and_resuming():
         
         campaign_id = test_campaign_data["campaign_id"]
         
-        # 2. Get campaign data
-        print("\n2. Getting campaign data...")
-        response = requests.get(f"{PYTHON_API_URL}/campaign_data/{campaign_id}")
-        
-        if response.status_code == 200:
-            data = response.json()
-            print("✓ Campaign data retrieved successfully")
-            print(f"  - Status: {data.get('status')}")
-            print(f"  - Sent count: {data.get('sent_count')}")
+        # 2. Ensure edit endpoints are not available
+        print("\n2. Checking removed edit endpoints...")
+        r1 = requests.get(f"{PYTHON_API_URL}/campaign_data/{campaign_id}")
+        r2 = requests.post(f"{PYTHON_API_URL}/update_campaign/{campaign_id}")
+        if r1.status_code == 404 and r2.status_code == 404:
+            print("✓ Edit routes return 404 as expected")
         else:
-            print(f"✗ Failed to get campaign data: {response.text}")
+            print("✗ Edit routes still exist")
             return False
         
-        # 3. Update campaign data
-        print("\n3. Updating campaign data...")
-        updated_data = {
-            "message": "Updated test message for campaign editing",
-            "limit": 10,
-            "account_id": 1,
-            "session": "test_session_string"
-        }
-        
-        response = requests.post(f"{PYTHON_API_URL}/update_campaign/{campaign_id}", 
-                               json=updated_data)
-        
-        if response.status_code == 200:
-            print("✓ Campaign updated successfully")
-        else:
-            print(f"✗ Failed to update campaign: {response.text}")
-            return False
-        
-        # 4. Stop the campaign
-        print("\n4. Stopping campaign...")
+        # 3. Stop the campaign
+        print("\n3. Stopping campaign...")
         response = requests.post(f"{PYTHON_API_URL}/stop_campaign/{campaign_id}")
         
         if response.status_code == 200:
@@ -79,8 +57,8 @@ def test_campaign_editing_and_resuming():
             print(f"✗ Failed to stop campaign: {response.text}")
             return False
         
-        # 5. Resume the campaign
-        print("\n5. Resuming campaign...")
+        # 4. Resume the campaign
+        print("\n4. Resuming campaign...")
         response = requests.post(f"{PYTHON_API_URL}/resume_campaign/{campaign_id}")
         
         if response.status_code == 200:
@@ -89,8 +67,8 @@ def test_campaign_editing_and_resuming():
             print(f"✗ Failed to resume campaign: {response.text}")
             return False
         
-        # 6. Check final status
-        print("\n6. Checking final campaign status...")
+        # 5. Check final status
+        print("\n5. Checking final campaign status...")
         response = requests.get(f"{PYTHON_API_URL}/campaign_status/{campaign_id}")
         
         if response.status_code == 200:


### PR DESCRIPTION
## Summary
- remove obsolete campaign editing endpoints
- update worker to drop proxy routes
- simplify campaign info display with compact filters
- drop edit modal from monitor UI
- adjust tests for removed routes

## Testing
- `python -m py_compile python_api/main.py`
- `./tests/run_all.sh` *(fails: Could not connect to Python API)*

------
https://chatgpt.com/codex/tasks/task_e_6873a894a0b08331a7c26ab934707095