### PR TITLE
Enable full chat categorization

### DIFF
--- a/frontend/src/components/CampaignMonitor.jsx
+++ b/frontend/src/components/CampaignMonitor.jsx
@@ -44,10 +44,14 @@ export default function CampaignMonitor({ accountId }) {
       console.log('Running campaigns data:', data)
       
       if (response.ok) {
-        const allCampaigns = data.campaigns || []
+        const allCampaigns = (data.campaigns || []).map(c => {
+          let f = {}
+          try { f = c.filters_json ? JSON.parse(c.filters_json) : {} } catch {}
+          return { ...c, categoryUpdate: !!f.categorize_only }
+        })
         const runningCampaigns = allCampaigns.filter(c => c.status === 'running')
         const stoppedCampaigns = allCampaigns.filter(c => c.status === 'stopped' || c.status === 'completed')
-        
+
         setRunning([...runningCampaigns, ...stoppedCampaigns])
         
         // If no active campaign is selected and there are campaigns, select the first one
@@ -193,17 +197,21 @@ export default function CampaignMonitor({ accountId }) {
                 onClick={() => {
                   setActiveId(c.id)
                 }}
-                className={`cursor-pointer p-2 border rounded ${c.id === activeId ? 'bg-blue-50 border-blue-300' : 'hover:bg-gray-50'}`}
+                className={`cursor-pointer p-2 border rounded ${c.categoryUpdate ? 'bg-purple-50 border-purple-300' : c.id === activeId ? 'bg-blue-50 border-blue-300' : 'hover:bg-gray-50'}`}
               >
                 <div className="flex justify-between items-start">
                   <div className="flex-1">
-                    <p className="text-sm font-medium">Campaign #{c.id}</p>
-                    <p className="text-xs text-gray-600">{c.message_text?.slice(0, 60)}...</p>
+                    <p className="text-sm font-medium">{c.categoryUpdate ? 'Category Update' : `Campaign #${c.id}`}</p>
+                    {!c.categoryUpdate && (
+                      <p className="text-xs text-gray-600">{c.message_text?.slice(0, 60)}...</p>
+                    )}
                     <p className="text-xs text-gray-500">Status: {c.status}</p>
                   </div>
                   <div className="flex gap-1 ml-2">
 
-                    {c.status === 'stopped' ? (
+                    {c.categoryUpdate ? (
+                      <span className="px-2 py-1 text-xs bg-purple-200 text-purple-800 rounded">Update</span>
+                    ) : c.status === 'stopped' ? (
                       <button
                         onClick={(e) => {
                           e.stopPropagation()

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -955,47 +955,47 @@ router.post("/categorize", async (request: Request, env: Env) => {
   return jsonResponse({ updated, logs });
 });
 
-// Trigger a categorization-only campaign to refresh chat overview
+// Categorize all chats for an account and create a monitoring campaign
 router.post("/analytics/update", async (request: Request, env: Env) => {
   const { account_id, telegram_session_id } = (await request.json()) as any;
   const accountId = Number(account_id || 0);
   const sessionId = Number(telegram_session_id || 0);
-  if (!accountId || !sessionId) return jsonResponse({ error: "missing parameters" }, 400);
+  if (!accountId || !sessionId) {
+    return jsonResponse({ error: "missing parameters" }, 400);
+  }
 
   const insertRes = await env.DB.prepare(
-    "INSERT INTO campaigns (account_id, telegram_session_id, message_text, status, filters_json) VALUES (?1, ?2, ?3, 'created', ?4)",
+    "INSERT INTO campaigns (account_id, telegram_session_id, message_text, status, filters_json) VALUES (?1, ?2, ?3, 'running', ?4)",
   )
-    .bind(accountId, sessionId, 'Categorize chats', JSON.stringify({ categorize_only: true }))
+    .bind(accountId, sessionId, "Category Update", JSON.stringify({ categorize_only: true }))
     .run();
   const newId = insertRes.lastRowId;
 
   const row = await env.DB.prepare(
-    `SELECT c.id, c.account_id, c.message_text, c.telegram_session_id, c.filters_json, t.encrypted_session_data
-     FROM campaigns c JOIN telegram_sessions t ON c.telegram_session_id=t.id
-     WHERE c.id=?1`,
+    "SELECT encrypted_session_data FROM telegram_sessions WHERE id=?1 AND account_id=?2",
   )
-    .bind(newId)
+    .bind(sessionId, accountId)
     .first();
-  if (!row) return jsonResponse({ error: "campaign not found" }, 500);
-  let filters: any = {};
-  try { filters = row.filters_json ? JSON.parse(row.filters_json) : {}; } catch {}
-  const requestBody = {
-    session: row.encrypted_session_data,
-    message: row.message_text,
-    account_id: row.account_id,
-    campaign_id: row.id,
-    ...filters,
-  };
-  await env.DB.prepare("UPDATE campaigns SET status=?1 WHERE id=?2")
-    .bind("running", newId)
-    .run();
-  await fetch(`${env.PYTHON_API_URL}/execute_campaign`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(requestBody),
-  });
+  if (!row || !row.encrypted_session_data) {
+    return jsonResponse({ error: "session not found" }, 400);
+  }
 
-  return jsonResponse({ id: newId, status: "started" });
+  try {
+    await fetch(`${env.PYTHON_API_URL}/categorize_all`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session: row.encrypted_session_data,
+        account_id: accountId,
+        campaign_id: newId,
+      }),
+    });
+  } catch (err) {
+    console.error("categorize_all fetch error", err);
+    return jsonResponse({ error: "python request failed" }, 500);
+  }
+
+  return jsonResponse({ campaign_id: newId, status: "started" });
 });
 
 // Analytics summary


### PR DESCRIPTION
## Summary
- add asynchronous `categorize_all` route to Python API
- create monitoring campaign from worker when updating analytics
- show running state and Monitor button in Analytics dashboard
- display "Category Update" entry in Campaign Monitor

## Testing
- `pip install -r python_api/requirements.txt`
- `bash tests/run_all.sh` *(fails: Could not connect to Python API)*

------
https://chatgpt.com/codex/tasks/task_e_687639b5785883318e77e781e91d1457