### PR TITLE
Add WordPress poster designer plugin

### DIFF
--- a/wp-poster-designer/poster-admin.js
+++ b/wp-poster-designer/poster-admin.js
@@ -1,0 +1,15 @@
+(function($){
+    function init() {
+        var canvas = new fabric.Canvas('poster-canvas');
+        var dataField = $('#poster-design');
+        if (dataField.val()) {
+            canvas.loadFromJSON(dataField.val(), canvas.renderAll.bind(canvas));
+        }
+        $('#save-poster-design').on('click', function(){
+            dataField.val(JSON.stringify(canvas.toJSON()));
+        });
+    }
+    if (typeof fabric !== 'undefined') {
+        jQuery(init);
+    }
+})(jQuery);

--- a/wp-poster-designer/poster-designer.php
+++ b/wp-poster-designer/poster-designer.php
@@ -1,0 +1,71 @@
+<?php
+/*
+Plugin Name: WP Poster Designer
+Description: Design poster templates in admin and allow users to customize and download.
+Version: 1.0.0
+Author: Codex AI
+*/
+
+if (!defined('ABSPATH')) exit;
+
+class WP_Poster_Designer {
+    public function __construct() {
+        add_action('init', [$this, 'register_post_type']);
+        add_action('add_meta_boxes', [$this, 'add_meta_boxes']);
+        add_action('save_post_poster_template', [$this, 'save_design']);
+        add_shortcode('poster_designer', [$this, 'render_shortcode']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_scripts']);
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_front_scripts']);
+    }
+
+    public function register_post_type() {
+        register_post_type('poster_template', [
+            'label' => 'Poster Templates',
+            'public' => false,
+            'show_ui' => true,
+            'supports' => ['title'],
+        ]);
+    }
+
+    public function add_meta_boxes() {
+        add_meta_box('poster_design_box', 'Poster Design', [$this, 'render_design_box'], 'poster_template', 'normal', 'high');
+    }
+
+    public function enqueue_admin_scripts($hook) {
+        if ($hook === 'post.php' || $hook === 'post-new.php') {
+            wp_enqueue_script('fabric', 'https://unpkg.com/fabric@5.2.4/dist/fabric.min.js');
+            wp_enqueue_script('poster-admin', plugins_url('poster-admin.js', __FILE__), ['fabric'], '1.0', true);
+        }
+    }
+
+    public function enqueue_front_scripts() {
+        wp_enqueue_script('fabric', 'https://unpkg.com/fabric@5.2.4/dist/fabric.min.js');
+        wp_enqueue_script('poster-front', plugins_url('poster-front.js', __FILE__), ['fabric'], '1.0', true);
+    }
+
+    public function render_design_box($post) {
+        $design = get_post_meta($post->ID, '_poster_design', true);
+        echo '<div id="poster-designer-canvas-wrapper"><canvas id="poster-canvas" width="600" height="800"></canvas></div>';
+        echo '<input type="hidden" id="poster-design" name="poster_design" value="' . esc_attr($design) . '" />';
+        echo '<button type="button" class="button" id="save-poster-design">Save Design</button>';
+    }
+
+    public function save_design($post_id) {
+        if (isset($_POST['poster_design'])) {
+            update_post_meta($post_id, '_poster_design', wp_kses_post($_POST['poster_design']));
+        }
+    }
+
+    public function render_shortcode($atts) {
+        $atts = shortcode_atts(['id' => 0], $atts);
+        $design = get_post_meta((int)$atts['id'], '_poster_design', true);
+        ob_start();
+        echo '<canvas id="poster-canvas-front" width="600" height="800"></canvas>';
+        echo '<button id="download-poster">Download</button>';
+        echo '<script>var POSTER_DATA = ' . json_encode($design ? $design : '') . ';</script>';
+        return ob_get_clean();
+    }
+}
+
+new WP_Poster_Designer();
+?>

--- a/wp-poster-designer/poster-front.js
+++ b/wp-poster-designer/poster-front.js
@@ -1,0 +1,17 @@
+(function($){
+    function init() {
+        var canvas = new fabric.Canvas('poster-canvas-front');
+        if (POSTER_DATA) {
+            try { canvas.loadFromJSON(POSTER_DATA, canvas.renderAll.bind(canvas)); } catch(e) {}
+        }
+        $('#download-poster').on('click', function(){
+            var link = document.createElement('a');
+            link.download = 'poster.png';
+            link.href = canvas.toDataURL({format: 'png'});
+            link.click();
+        });
+    }
+    if (typeof fabric !== 'undefined') {
+        jQuery(init);
+    }
+})(jQuery);


### PR DESCRIPTION
## Summary
- create plugin folder `wp-poster-designer`
- add `poster-designer.php` for managing poster templates and shortcode
- add admin and front-end JS for Fabric.js canvas editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884c7741c2c832f83badf0f5a0766bd